### PR TITLE
Firefox doesn't support the .innerText property on DOM elements; instead...

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -105,7 +105,10 @@ Rivets.bindings =
   enabled:
     stateBinding 'disabled', true
   text: (el, value) ->
-    el.innerText = value or ''
+    if el.innerText?
+      el.innerText = value or ''
+    else
+      el.textContent = value or ''
   html: (el, value) ->
     el.innerHTML = value or ''
   value: (el, value) ->


### PR DESCRIPTION
... it uses .textContent. o_O

This addresses #6.
