### PR TITLE
Enable a way of unbinding listeners

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -32,7 +32,7 @@ class Rivets.Binding
       @set Rivets.config.adapter.read @model, @keypath
 
     if @type in bidirectionals
-      @el.addEventListener('change', @publish)
+      @el.addEventListener 'change', @publish
 
   publish: (e) =>
     el = e.target or e.srcElement
@@ -43,7 +43,7 @@ class Rivets.Binding
     Rivets.config.adapter.unsubscribe @model, @keypath, @set
 
     if @type in bidirectionals
-      @el.removeEventListener('change', @publish)
+      @el.removeEventListener 'change', @publish
 
 # A collection of bindings for a parent element.
 class Rivets.View


### PR DESCRIPTION
This is quite important as in many apps models are long lived and having tons of listeners still attached to them when navigating away from a page is not a good idea.
