### PR TITLE
`setAttribute` doesn't correctly change checked state.

### DIFF
--- a/lib/rivets.js
+++ b/lib/rivets.js
@@ -151,10 +151,17 @@
 
   attributeBinding = function(attr) {
     return function(el, value) {
-      if (value) {
-        return el.setAttribute(attr, value);
-      } else {
-        return el.removeAttribute(attr);
+      switch (attr) {
+        case 'checked':
+          el.setAttribute('checked', value);
+          el.checked = value;
+          return el.defaultChecked = value;
+        default:
+          if (value) {
+            return el.setAttribute(attr, value);
+          } else {
+            return el.removeAttribute(attr);
+          }
       }
     };
   };

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -86,7 +86,16 @@ getInputValue = (el) ->
 # Returns an attribute binding routine for the specified attribute. This is what
 # `registerBinding` falls back to when there is no routine for the binding type.
 attributeBinding = (attr) -> (el, value) ->
-  if value then el.setAttribute attr, value else el.removeAttribute attr
+  switch attr
+    when 'checked'
+      el.setAttribute( 'checked', value )
+      el.checked = value
+      el.defaultChecked = value
+    else
+      if value
+        el.setAttribute attr, value
+      else
+        el.removeAttribute attr
 
 # Returns a state binding routine for the specified attribute. Can optionally be
 # negatively evaluated. This is used to build a lot of the core state binding


### PR DESCRIPTION
If the user changes the checked state of a checkbox input, `setAttribute` will stop updating the UI. It appears that internally the state is set but the interface doesn't match.

Fix is to use a more thorough approach for the checked case, somewhat like `getInputValue` already does.

[Here's a fiddle](http://jsfiddle.net/rfunduk/8FuxB/4/) I was using to experiment with rivets when I discovered this problem. It affects at least Chrome 20 and Firefox 13.0.

Run the fiddle, check some of the boxes first, then click 'toggle all'. Now uncheck some different boxes, and toggle a few more times to fully demonstrate the problem.

Finally, [here's another fiddle](http://jsfiddle.net/rfunduk/8FuxB/5/) using my forked version to demonstrate the fix.
