### PR TITLE
Reverse set the model from the element on initial bind

### DIFF
--- a/lib/rivets.js
+++ b/lib/rivets.js
@@ -37,7 +37,7 @@
     };
 
     Binding.prototype.bind = function() {
-      var _ref,
+      var value, _ref,
         _this = this;
       if (Rivets.config.preloadData) {
         this.set();
@@ -46,11 +46,14 @@
         return _this.set(value);
       });
       if (_ref = this.type, __indexOf.call(bidirectionals, _ref) >= 0) {
-        return this.el.addEventListener('change', function(e) {
+        this.el.addEventListener('change', function(e) {
           var el;
           el = e.target || e.srcElement;
           return Rivets.config.adapter.publish(_this.context, _this.keypath, getInputValue(el));
         });
+        if (!Rivets.config.adapter.read(this.context, this.keypath) && (value = getInputValue(this.el))) {
+          return Rivets.config.adapter.publish(this.context, this.keypath, value);
+        }
       }
     };
 

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -34,6 +34,10 @@ class Rivets.Binding
       @el.addEventListener 'change', (e) =>
         el = e.target or e.srcElement
         Rivets.config.adapter.publish @context, @keypath, getInputValue el
+      # if our model has no value for a field, but the bound element does, set the
+      # value in the model
+      if !Rivets.config.adapter.read(@context, @keypath) && value = getInputValue @el
+        Rivets.config.adapter.publish @context, @keypath, value
 
 # Parses and stores the binding data for an entire view binding.
 class Rivets.View


### PR DESCRIPTION
If the model has no value for a given property, but the corresponding element does, update the model with that value. This is mostly the case with select lists that have no unselected state. The issue arises when the user makes no selection because the first (default) value of the select list is okay and no event is fired that would otherwise update the model.

Backbone.ModelBinding does this, and after converting to Rivets, I saw how the absence of this affected things:

https://github.com/derickbailey/backbone.modelbinding/blob/master/backbone.modelbinding.js#L253

Not sure if this is the approach you want to take for this scenario, so feel free to solve it in a different way. Perhaps the model should be initialized with default values that reflect the interface, and documentation around this is sufficient... In fact, I think that probably is a more elegant approach to take...
