### PR TITLE
Support passing multiple elements to Rivets.View

### DIFF
--- a/spec/rivets/functional.js
+++ b/spec/rivets/functional.js
@@ -90,6 +90,16 @@ describe('Functional', function() {
         expect(input.value).toBe(data.get('foo'));
       });
     });
+    
+    describe('Multiple', function() {
+      it('should bind a list of multiple elements', function() {
+        el.setAttribute('data-html', 'data.foo');
+        input.setAttribute('data-value', 'data.foo');
+        rivets.bind([el, input], bindData);
+        expect(el).toHaveTheTextContent(data.get('foo'));
+        expect(input.value).toBe(data.get('foo'));
+      });
+    });
   });
 
   describe('Updates', function() {

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -69,8 +69,8 @@ class Rivets.Binding
 class Rivets.View
   # The parent DOM element and the model objects for binding are passed into the
   # constructor.
-  constructor: (@el, @models) ->
-    @el = @el.get(0) if @el.jquery
+  constructor: (@els, @models) ->
+    @els = [@els] unless (@els.jquery || @els instanceof Array)
     @build()
 
   # Regular expression used to match binding attributes.
@@ -102,8 +102,9 @@ class Rivets.View
 
           @bindings.push new Rivets.Binding node, type, bindType, model, keypath, pipes
 
-    parseNode @el
-    parseNode node for node in @el.getElementsByTagName '*'
+    for el in @els
+      parseNode el
+      parseNode node for node in el.getElementsByTagName '*'
 
   # Binds all of the current bindings for this view.
   bind: =>


### PR DESCRIPTION
In my application, I've got a series of nested views. Given that Rivets will bind all elements under the root, this would result in a situation where I have multiple overlapping bindings.

As a solution to this, this patch allows an array of elements to be passed to `rivets.bind()`. This allows me to use jquery to select all the elements I want bound, and then provide just those to rivets, instead of just providing the top level element.

I've added a spec for this behaviour too, but I'm not quite sure I found the right place for it.
