### PR TITLE
Default to an empty string for undefined value bindings

### DIFF
--- a/spec/rivets/routines.js
+++ b/spec/rivets/routines.js
@@ -37,6 +37,11 @@ describe('Routines', function() {
       rivets.routines.value(input, 'pitchfork');
       expect(input.value).toBe('pitchfork');
     });
+    
+    it("applies a default value to the element when the model doesn't contain it", function() {
+      rivets.routines.value(input, undefined);
+      expect(input.value).toBe('');
+    });
   });
 
   describe('show', function() {

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -174,7 +174,7 @@ Rivets.routines =
   html:  (el, value) ->
     el.innerHTML = value or ''
   value: (el, value) ->
-    el.value = value
+    el.value = value or ''
   text: (el, value) ->
     if el.innerText?
       el.innerText = value or ''


### PR DESCRIPTION
Fix for #36 - defaults an `undefined` model value to an empty string.
