### PR TITLE
Fix IE8 & FF3.6 event issues, fix IE8 string split issue

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -72,7 +72,7 @@ class Rivets.Binding
             @model[@keypath]
           else
             Rivets.config.adapter.read @model, @keypath
-        
+
         Rivets.config.adapter.subscribe @model, keypath, callback
 
     if @type in @bidirectionals
@@ -122,11 +122,12 @@ class Rivets.View
           type = attribute.name.replace bindingRegExp, ''
           pipes = (pipe.trim() for pipe in attribute.value.split '|')
           context = (ctx.trim() for ctx in pipes.shift().split '>')
-          path = context.shift().split /(\.|:)/
+          path = context.shift()
+          splitPath = path.split /\.|:/
           options.formatters = pipes
-          model = @models[path.shift()]
-          options.bypass = path.shift() is ':'
-          keypath = path.join()
+          model = @models[splitPath.shift()]
+          options.bypass = path.indexOf(":") != -1
+          keypath = splitPath.join()
 
           if dependencies = context.shift()
             options.dependencies = dependencies.split /\s+/


### PR DESCRIPTION
Hey,

Really great project! Had some minor issues with older browsers that I have attempted to fix.

Added a third argument (false) to addEventListener/removeEventListener, this is needed in older browsers setting useCapture.

Prefixed oldIE events with "on"

Removed the split regex grouping from parseNode.
This does not seem to work in IE8 as expected. Returns the array without the matched group.
So did without the group split, and instead checked the special bypass case by searching the path string directly.

Cheers
