### PR TITLE
IE8 fix.  

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -278,7 +278,7 @@ iterationBinding = (name) -> (el, collection, binding) ->
     data[name] = item
     itemEl = el.cloneNode true
     previous = binding.iterated[binding.iterated.length - 1] or binding.marker
-    binding.marker.parentNode.insertBefore itemEl, previous.nextSibling
+    binding.marker.parentNode.insertBefore itemEl, previous.nextSibling ? null
 
     binding.iterated.push
       el: itemEl


### PR DESCRIPTION
This IE8 fix worked for me!  I suspect it will also help on windows mobile 7.5 (not yet tested though).

second argument must be a valid node or null. from http://stackoverflow.com/questions/9377887/ie-doesnt-support-insertbefore
