### PR TITLE
Advanced custom binders API

### DIFF
--- a/spec/rivets/binding.js
+++ b/spec/rivets/binding.js
@@ -19,7 +19,7 @@ describe('Rivets.Binding', function() {
   });
 
   it('gets assigned the proper binder routine matching the identifier', function() {
-    expect(binding.binder.routine).toBe(rivets.routines.text);
+    expect(binding.binder.routine).toBe(rivets.binders.text);
   });
 
   describe('bind()', function() {

--- a/spec/rivets/routines.js
+++ b/spec/rivets/routines.js
@@ -18,13 +18,13 @@ describe('Routines', function() {
 
   describe('text', function() {
     it("sets the element's text content", function() {
-      rivets.routines.text(el, '<em>gluten-free</em>');
+      rivets.binders.text(el, '<em>gluten-free</em>');
       expect(el.textContent || el.innerText).toBe('<em>gluten-free</em>');
       expect(el.innerHTML).toBe('&lt;em&gt;gluten-free&lt;/em&gt;');
     });
 
     it("sets the element's text content to zero when a numeric zero is passed", function() {
-        rivets.routines.text(el, 0);
+        rivets.binders.text(el, 0);
         expect(el.textContent || el.innerText).toBe('0');
         expect(el.innerHTML).toBe('0');
     });
@@ -32,13 +32,13 @@ describe('Routines', function() {
 
   describe('html', function() {
     it("sets the element's HTML content", function() {
-      rivets.routines.html(el, '<strong>fixie</strong>');
+      rivets.binders.html(el, '<strong>fixie</strong>');
       expect(el.textContent || el.innerText).toBe('fixie');
       expect(el.innerHTML).toBe('<strong>fixie</strong>');
     });
 
     it("sets the element's HTML content to zero when a zero value is passed", function() {
-      rivets.routines.html(el, 0);
+      rivets.binders.html(el, 0);
         expect(el.textContent || el.innerText).toBe('0');
         expect(el.innerHTML).toBe('0');
     });
@@ -46,17 +46,17 @@ describe('Routines', function() {
 
   describe('value', function() {
     it("sets the element's value", function() {
-      rivets.routines.value.routine(input, 'pitchfork');
+      rivets.binders.value.routine(input, 'pitchfork');
       expect(input.value).toBe('pitchfork');
     });
     
     it("applies a default value to the element when the model doesn't contain it", function() {
-      rivets.routines.value.routine(input, undefined);
+      rivets.binders.value.routine(input, undefined);
       expect(input.value).toBe('');
     });
 
     it("sets the element's value to zero when a zero value is passed", function() {
-      rivets.routines.value.routine(input, 0);
+      rivets.binders.value.routine(input, 0);
       expect(input.value).toBe('0');
     });
   });
@@ -64,14 +64,14 @@ describe('Routines', function() {
   describe('show', function() {
     describe('with a truthy value', function() {
       it('shows the element', function() {
-        rivets.routines.show(el, true);
+        rivets.binders.show(el, true);
         expect(el.style.display).toBe('');
       });
     });
 
     describe('with a falsey value', function() {
       it('hides the element', function() {
-        rivets.routines.show(el, false);
+        rivets.binders.show(el, false);
         expect(el.style.display).toBe('none');
       });
     });
@@ -80,14 +80,14 @@ describe('Routines', function() {
   describe('hide', function() {
     describe('with a truthy value', function() {
       it('hides the element', function() {
-        rivets.routines.hide(el, true);
+        rivets.binders.hide(el, true);
         expect(el.style.display).toBe('none');
       });
     });
 
     describe('with a falsey value', function() {
       it('shows the element', function() {
-        rivets.routines.hide(el, false);
+        rivets.binders.hide(el, false);
         expect(el.style.display).toBe('');
       });
     });
@@ -96,14 +96,14 @@ describe('Routines', function() {
   describe('enabled', function() {
     describe('with a truthy value', function() {
       it('enables the element', function() {
-        rivets.routines.enabled(el, true);
+        rivets.binders.enabled(el, true);
         expect(el.disabled).toBe(false);
       });
     });
 
     describe('with a falsey value', function() {
       it('disables the element', function() {
-        rivets.routines.enabled(el, false);
+        rivets.binders.enabled(el, false);
         expect(el.disabled).toBe(true);
       });
     });
@@ -112,14 +112,14 @@ describe('Routines', function() {
   describe('disabled', function() {
     describe('with a truthy value', function() {
       it('disables the element', function() {
-        rivets.routines.disabled(el, true);
+        rivets.binders.disabled(el, true);
         expect(el.disabled).toBe(true);
       });
     });
 
     describe('with a falsey value', function() {
       it('enables the element', function() {
-        rivets.routines.disabled(el, false);
+        rivets.binders.disabled(el, false);
         expect(el.disabled).toBe(false);
       });
     });
@@ -128,14 +128,14 @@ describe('Routines', function() {
   describe('checked', function() {
     describe('with a truthy value', function() {
       it('checks the element', function() {
-        rivets.routines.checked.routine(el, true);
+        rivets.binders.checked.routine(el, true);
         expect(el.checked).toBe(true);
       });
     });
 
     describe('with a falsey value', function() {
       it('unchecks the element', function() {
-        rivets.routines.checked.routine(el, false);
+        rivets.binders.checked.routine(el, false);
         expect(el.checked).toBe(false);
       });
     });
@@ -144,14 +144,14 @@ describe('Routines', function() {
   describe('unchecked', function() {
     describe('with a truthy value', function() {
       it('unchecks the element', function() {
-        rivets.routines.unchecked.routine(el, true);
+        rivets.binders.unchecked.routine(el, true);
         expect(el.checked).toBe(false);
       });
     });
 
     describe('with a falsey value', function() {
       it('checks the element', function() {
-        rivets.routines.unchecked.routine(el, false);
+        rivets.binders.unchecked.routine(el, false);
         expect(el.checked).toBe(true);
       });
     });

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -15,8 +15,8 @@ class Rivets.Binding
   # element, the type of binding, the model object and the keypath at which
   # to listen for changes.
   constructor: (@el, @type, @model, @keypath, @options = {}) ->
-    unless @binder = Rivets.routines[type]
-      for identifier, value of Rivets.routines
+    unless @binder = Rivets.binders[type]
+      for identifier, value of Rivets.binders
         if identifier isnt '*' and identifier.indexOf('*') isnt -1
           regexp = new RegExp "^#{identifier.replace('*', '.+')}$"
           if regexp.test type
@@ -24,7 +24,7 @@ class Rivets.Binding
             @args = new RegExp("^#{identifier.replace('*', '(.+)')}$").exec type
             @args.shift()
 
-    @binder or= Rivets.routines['*']
+    @binder or= Rivets.binders['*']
 
     if @binder instanceof Function
       @binder = {routine: @binder}
@@ -121,14 +121,14 @@ class Rivets.View
         for attribute in node.attributes
           if bindingRegExp.test attribute.name
             type = attribute.name.replace bindingRegExp, ''
-            unless binder = Rivets.routines[type]
-              for identifier, value of Rivets.routines
+            unless binder = Rivets.binders[type]
+              for identifier, value of Rivets.binders
                 if identifier isnt '*' and identifier.indexOf('*') isnt -1
                   regexp = new RegExp "^#{identifier.replace('*', '.+')}$"
                   if regexp.test type
                     binder = value
 
-            binder or= Rivets.routines['*']
+            binder or= Rivets.binders['*']
 
             if binder.block
               skipNodes.push n for n in node.getElementsByTagName '*'
@@ -231,7 +231,7 @@ getInputValue = (el) ->
     else el.value
 
 # Core binding routines.
-Rivets.routines =
+Rivets.binders =
   enabled: (el, value) ->
     el.disabled = !value
 
@@ -345,7 +345,7 @@ Rivets.formatters = {}
 # The rivets module. This is the public interface that gets exported.
 rivets =
   # Exposes the core binding routines that can be extended or stripped down.
-  routines: Rivets.routines
+  binders: Rivets.binders
 
   # Exposes the formatters object to be extended.
   formatters: Rivets.formatters


### PR DESCRIPTION
This pull-request implements a more flexible API to define custom binders. All previously "special bindings" are now placed in rivets.routines along with all other binders/routines and their logic is completely self-contained, so you can override them or implement your own complex, stateful binders (such as iterators or custom two-way bindings). Have a look at the new [core binding routine implementations](https://github.com/mikeric/rivets/blob/372a30f1795a3b27d41391d40b6021a8905b6270/src/rivets.coffee#L233-336) to see how this all works.

Some of the features added in the new custom binders API:
- Wildcard matchers for routine identifiers like `each-*` or `class-*` (arguments are accessible in `binding.args`).
- Routines (binders in **0.4.x**) can now be defined as an object to allow specifying the following additional binding properties:
  - `bind`: (function) This function will get called on `binding.bind()`. Use it to store some initial state on the binding, or to set up any event listeners on the element (used in value, checked, unchecked, iteration).
  - `unbind`: (function) This function will get called on `binding.unbind()`. Use it to reset any state on the element that would have been changed from the routine getting called, or to unbind any event listeners on the element that you've set up.
  - `block`: (true or false) Blocks the current node and child nodes from being parsed (used for iteration binding).
  - `publishes`: (true or false) Set this to true if you want `view.publish()` to call publish on these bindings (used for value, checked, unchecked, and any other bidirectional binder).
  - `function`: (true or false) Set to true if the value of this binding is meant to be used as a function. This tells the binding not to execute the function before passing it through the formatters (used in the `on-[event]` binding).
  - `routine`: (function) This is the routine function, it gets called when an observed attribute changes. This is no different from the way routines work in **<= 0.3.13**. The routine is actually optional now, for example if your binding only reacts to element changes (one-way binding from el to model), then you can leave this out.
- All above functions defined on the binder will be called in the context of the `Rivets.Binding` instance, so you can access all properties on the binding from `this` / `@`.
