### PR TITLE
Fix for IE8 getElementsByTagName (do not parse comment nodes)

### DIFF
--- a/lib/rivets.js
+++ b/lib/rivets.js
@@ -201,6 +201,7 @@
       parseNode = function(node) {
         var attribute, attributes, binder, binding, context, ctx, dependencies, identifier, keypath, model, n, options, path, pipe, pipes, regexp, splitPath, type, value, _i, _j, _k, _len, _len1, _len2, _ref, _ref1, _ref2, _ref3;
         if (__indexOf.call(skipNodes, node) < 0) {
+          if (!node.attributes) return;
           _ref = node.attributes;
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             attribute = _ref[_i];


### PR DESCRIPTION
Hello:

Today I found out that IE8's getElementsByTagName returns not only actual nodes but also others such as comments. This is quite annoying as comment nodes break rivets in IE8 and, of course, I do not want to remove comments.

The simplest and quickest solution I came up was to only parse nodes for which .attributes is not null.

Hope you guys find it useful.
Mariano.
