### PR TITLE
each-* will now insert between siblings [Closes #106]

### DIFF
--- a/spec/rivets/functional.js
+++ b/spec/rivets/functional.js
@@ -145,6 +145,23 @@ describe('Functional', function() {
         expect(el.getElementsByTagName('li')[0]).toHaveTheTextContent('a');
         expect(el.getElementsByTagName('li')[0].className).toBe('bar');
       });
+
+      it('should insert items between any surrounding elements', function(){
+        firstItem = document.createElement('li');
+        lastItem = document.createElement('li');
+        firstItem.textContent = 'first';
+        lastItem.textContent = 'last';
+        list.appendChild(lastItem);
+        list.insertBefore(firstItem, listItem);
+
+        listItem.setAttribute('data-text', 'item:name');
+
+        rivets.bind(el, bindData);
+        expect(el.getElementsByTagName('li')[0]).toHaveTheTextContent('first');
+        expect(el.getElementsByTagName('li')[1]).toHaveTheTextContent('a');
+        expect(el.getElementsByTagName('li')[2]).toHaveTheTextContent('b');
+        expect(el.getElementsByTagName('li')[3]).toHaveTheTextContent('last');
+      })
     });
   });
 

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -344,7 +344,10 @@ Rivets.binders =
         data[n] = m for n, m of @view.models
         data[@args[0]] = item
         itemEl = el.cloneNode true
-        previous = @iterated[@iterated.length - 1] or @marker
+        if @iterated.length > 0
+          previous = @iterated[@iterated.length - 1].els[0]
+        else
+          previous = @marker
         @marker.parentNode.insertBefore itemEl, previous.nextSibling ? null
         @iterated.push rivets.bind itemEl, data
 


### PR DESCRIPTION
This commit fixes an issue with the each-\* binding where all but the
first element would be inserted into incorrect positions when the
binding is used on an element with siblings.

The issue occurred because the code was passing a Rivets.View instance
in to insertBefore for all but the first element, which just caused the
element to be inserted last.
