### PR TITLE
Avoid changing cursor position in active inputs with value bindings

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -308,7 +308,7 @@ Rivets.binders =
     routine: (el, value) ->
       if el.type is 'select-multiple'
         o.selected = o.value in value for o in el if value?
-      else
+      else if value isnt el.value
         el.value = if value? then value else ''
 
   text: (el, value) ->


### PR DESCRIPTION
If an input element's 'change' event fires while the user is editing that input, data-value binding will overwrite the value with itself, causing the caret position to move to the end of the field on most browsers. This makes it difficult to publish changes on each keypress. I have addressed this by preventing setting el.value to its current value.

<!---
@huboard:{"order":47.0}
-->
