### PR TITLE
Maintain selection when performing value routine

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -357,8 +357,9 @@ Rivets.binders =
     routine: (el, value) ->
       if el.type is 'select-multiple'
         o.selected = o.value in value for o in el if value?
-      else if value isnt el.value
-        el.value = if value? then value else ''
+      else
+        maintainSelection el, ->
+          el.value = if value? then value else ''
 
   text: (el, value) ->
     if el.innerText?


### PR DESCRIPTION
Fix for #130 by getting the current selection and restoring the selection after setting the new value. This method is somewhat of an improvement over #138 since the input's value can actually change by way of a formatter without losing the user's cursor position or selection.

The downside to this method is that it adds some _really_ ugly workaround code for IE < 9.
