### PR TITLE
Added support for AMD, CommonJS strict (fixes #116, #136)

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -403,6 +403,6 @@ factory = (exports) ->
 if typeof exports == 'object'
   factory(exports)
 else if typeof define == 'function' && define.amd
-  define ['exports'], factory
+  define ['exports'], (exports) -> @rivets = factory(exports)
 else
   factory(@rivets = {})


### PR DESCRIPTION
Based on [UMD example](https://github.com/umdjs/umd/blob/master/commonjsStrictGlobal.js).

I've also added better CommonJS support. The old version did not support strict implementations (which should use the `exports` object directly instead of the `module` object). Sadly this means I had to extract the local `rivets` object into a `factory` function, but this should not affect any other code.
