### PR TITLE
Fixed implicit return in AMD code

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -403,6 +403,8 @@ factory = (exports) ->
 if typeof exports == 'object'
   factory(exports)
 else if typeof define == 'function' && define.amd
-  define ['exports'], (exports) -> @rivets = factory(exports)
+  define ['exports'], (exports) ->
+    factory(@rivets = exports)
+    return exports
 else
   factory(@rivets = {})


### PR DESCRIPTION
I accidentally the factory's return value and CoffeeScript unhelpfully returns the last expression in the function, so the AMD definition gets mangled (and the browser global too).

I fixed that by assigning the `exports` object to the browser global explicitly and returning that explicitly from the AMD module definition.

I haven't changed the factory function because a trailing `return exports` would be too easy to miss.

Sorry about the mess.
