### PR TITLE
View context updating

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -123,6 +123,13 @@ class Rivets.Binding
 
         @view.config.adapter.unsubscribe model, keypath, @sync
 
+  # Updates the binding's model from what is currently set on the view. Unbinds
+  # the old model first and then re-binds with the new model.
+  update: =>
+    @unbind()
+    @model = @view.models[@key]
+    @bind()
+
 # A collection of bindings built from a set of parent elements.
 class Rivets.View
   # The DOM elements and the model objects for binding are passed into the
@@ -221,6 +228,12 @@ class Rivets.View
   # Publishes the input values from the view back to the model (reverse sync).
   publish: =>
     binding.publish() for binding in @select (b) -> b.binder.publishes
+
+  # Updates the view's models along with any affected bindings.
+  update: (models = {}) =>
+    for key, model of models
+      @models[key] = model
+      binding.update() for binding in @select (b) -> b.key is key
 
 # Cross-browser event binding.
 bindEvent = (el, event, handler, context) ->


### PR DESCRIPTION
This pull-request adds a much needed API for updating models on a currently bound view. I've seen this being done a couple of ways, but most often I see this as an example.

``` javascript
// bind a view with two model contexts.
view = rivets.bind(el, {item: item, user: john})

// unbind all current bindings for the view.
view.unbind()

// change the models on the view.
view.models = {item: item, user: jane}

// rebuild the view so that we get new bindings
// that have references to the new models.
view.build()

// finally, bind the view's binding instances.
view.bind()
```

Aside from being verbose and order-sensitive (otherwise introducing memory leaks), it's also slow because we need to parse the DOM tree when calling `view.build()`. Another issue is that we're doing unnecessary rebuilding of bindings for the "item" model, even though it didn't change at all (only "user" changed).

This pull request adds a new function to the view, `update`, which takes an object containing only the models that you wish to change.

``` javascript
view.update({user: jane})
```

Now only the bindings that we're bound to "user" will get updated and re-bound, all other bindings will be unaffected by the change and no DOM parsing is needed as we are just modifying the existing bindings that were bound to "user".
