### PR TITLE
Scope/view access within event handlers

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -251,8 +251,8 @@ class Rivets.View
 # Houses common utility functions used internally by Rivets.js.
 Rivets.Util =
   # Create a single DOM event binding.
-  bindEvent: (el, event, handler, context) ->
-    fn = (e) -> handler.call context, e
+  bindEvent: (el, event, handler, view) ->
+    fn = (ev) -> handler.call @, ev, view
 
     if window.jQuery?
       el = jQuery el
@@ -364,7 +364,7 @@ Rivets.binders =
     function: true
     routine: (el, value) ->
       Rivets.Util.unbindEvent el, @args[0], @currentListener if @currentListener
-      @currentListener = Rivets.Util.bindEvent el, @args[0], value, @model
+      @currentListener = Rivets.Util.bindEvent el, @args[0], value, @view
 
   "each-*":
     block: true


### PR DESCRIPTION
Includes the `Rivets.View` instance as the second argument in event handlers called from an `on-[event]` binding.

``` javascript
controller = {
  removeItem: function(ev, view) {
    this // original event handler's context (likely the DOM node)
    ev   // original event handler's event object
    view // Rivets.View instance of the event binding

    items.remove(view.models.item)
  }
}
```

Closes #112, Closes #161
