### PR TITLE
Event Handler Configuration

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -358,6 +358,10 @@ Rivets.binders =
 
   "on-*":
     function: true
+
+    unbind: (el) ->
+      Rivets.Util.unbindEvent el, @args[0], @handler if @handler
+
     routine: (el, value) ->
       binding = this
       Rivets.Util.unbindEvent el, @args[0], @handler if @handler


### PR DESCRIPTION
Adds a configuration option for [event handler APIs](https://github.com/mikeric/rivets/issues/161#issuecomment-18307472). Like all other configuration, this can be set globally on `rivets.config` or locally to a particular `Rivets.View` instance.

The default event handler configuration passes one extra object to the handler — the `view.models` object. Here's an example of what an event handler would look like for the default configuration.

``` javascript
completeItem: function(ev, models) {
  models.item.set({completed: true})
}
```

To change this API, you can overwrite the `rivets.config.handler` function.

``` javascript
rivets.config.handler = function(fn, context, ev, binding) {
  fn.call(context, ev, binding.model, binding.view)
}
```

**Update:** the handler configuration is now called in the context of the function, shifting the other 3 arguments back one.

``` javascript
rivets.config.handler = function(context, ev, binding) {
  this.call(context, ev, binding.model, binding.view)
}
```

Closes #161
