### PR TITLE
Store models reference on view

### DIFF
--- a/spec/rivets/routines.js
+++ b/spec/rivets/routines.js
@@ -253,4 +253,29 @@ describe('Routines', function() {
       });
     });
   });
+
+  // this is less than ideal, but without being able to access
+  // Rivets.View, it is hard to isolate the options being passed
+  describe('each', function() {
+    var view, models, span;
+
+    beforeEach(function() {
+      span = document.createElement('span');
+      span.setAttribute('data-each-foo', 'obj:foos');
+      el.appendChild(span);
+      models = { obj: { foos: [ {} ] } };
+      opts = {}
+      view = rivets.bind(el, models, opts);
+    });
+
+    it('should use a cloned models object for each view', function() {
+      var iteratedView = view.bindings[0].iterated[0];
+      expect(iteratedView.models).not.toBe(models)
+    })
+
+    it('should retain reference to original models object on each view', function() {
+      var iteratedView = view.bindings[0].iterated[0];
+      expect(iteratedView.modelsRef).toBe(models)
+    })
+  });
 });

--- a/spec/rivets/view.js
+++ b/spec/rivets/view.js
@@ -1,0 +1,32 @@
+describe('Rivets.View', function() {
+  var models, el, view, opts;
+
+  beforeEach(function() {
+    rivets.configure({
+      adapter: {
+        subscribe: function() {},
+        unsubscribe: function() {},
+        read: function() {},
+        publish: function() {}
+      }
+    });
+
+    models = { obj: {} };
+    el = document.createElement('div');
+    opts = {};
+    view = rivets.bind(el, models, opts);
+  });
+
+  describe('#modelsRef', function() {
+
+    it('should default to models object', function() {
+      expect(view.modelsRef).toBe(models);
+    });
+
+    it('should override with option.modelsRef', function() {
+      opts = { modelsRef: {} };
+      view = rivets.bind(el, models, opts);
+      expect(view.modelsRef).toBe(opts.modelsRef);
+    });
+  });
+});

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -152,6 +152,7 @@ class Rivets.View
   # context of the view and it's bindings.
   constructor: (@els, @models, @options = {}) ->
     @els = [@els] unless (@els.jquery || @els instanceof Array)
+    @modelsRef = @options.modelsRef || @models
 
     for option in ['config', 'binders', 'formatters']
       @[option] = {}
@@ -458,6 +459,7 @@ Rivets.binders =
             @marker
 
           options =
+            modelsRef: @view.models
             binders: @view.options.binders
             formatters: @view.options.formatters
             config: {}


### PR DESCRIPTION
This PR introduces a reference on every view that points to the original models object that it is scoped to. 

Currently, in the 'each-*' binding routine, the models object gets rebuilt for independence among the sub-views. This means that when you are inside of an event callback, you cannot alter properties on the original object.

Adding a reference to the original model, allows an event binding handler like this:
```javascript
  rivets.configure({
    handler: function(context, ev, binding) {
      this.call(binding.view.modelsRef, ev, binding.view.models);
    }
  });
```
And this terribly contrived, but hopefully demonstrative, view:
```javascript
  function View() {
    this.data = 'foo';
    this.count = 0;
  }

  // function bound within an iteration block
  View.prototyp.myClickEvent = function(e, ctx) {
    this.data = ctx.someIteratedModel;
    this.count++;
  }
  
  rivets.bind(div, new View)