### PR TITLE
Components

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -158,7 +158,7 @@ class Rivets.Binding
 # Rivets.ComponentBinding
 # -----------------------
 
-# A component view encapsulated in a binding within it's parent view.
+# A component view encapsulated as a binding within it's parent view.
 class Rivets.ComponentBinding extends Rivets.Binding
   # Initializes a component binding for the specified view. The raw component
   # element is passed in along with the component type. Attributes and scope
@@ -174,7 +174,7 @@ class Rivets.ComponentBinding extends Rivets.Binding
       else
         @inflections[attribute.name] = attribute.value
 
-  # Intercepts `Rivets.View::sync` since component bindings are not bound to a
+  # Intercepts `Rivets.Binding::sync` since component bindings are not bound to a
   # particular model to update it's value.
   sync: ->
 
@@ -186,12 +186,12 @@ class Rivets.ComponentBinding extends Rivets.Binding
 
     result
 
-  # Intercepts `Rivets.View::update` to be called on `@componentView` with a
+  # Intercepts `Rivets.Binding::update` to be called on `@componentView` with a
   # localized map of the models.
   update: (models) =>
     @componentView?.update @locals models
 
-  # Intercepts `Rivets.View::bind` to build `@componentView` with a localized
+  # Intercepts `Rivets.Binding::bind` to build `@componentView` with a localized
   # map of models from the root view. Bind `@componentView` on subsequent calls.
   bind: =>
     if @componentView?
@@ -201,7 +201,7 @@ class Rivets.ComponentBinding extends Rivets.Binding
       (@componentView = new Rivets.View(el, @locals(), @view.options)).bind()
       @el.parentNode.replaceChild el, @el
 
-  # Intercept `Rivets.View::unbind` to be called on `@componentView`.
+  # Intercept `Rivets.Binding::unbind` to be called on `@componentView`.
   unbind: =>
     @componentView?.unbind()
 


### PR DESCRIPTION
This pull-request adds a simple, yet extremely flexible API for encapsulating reusable views. Components are declared as an element prefixed with `rivets.config.prefix` or `rv` and get compiled into their own `Rivets.View` instance on bind.

It's important to note that these elements will only exists in the template. They get replaced with a different DOM structure on bind, so you can think of it more as a set of instructions that get assembled into something more complex. Their purpose is purely for encapsulation and to clean up your templates, not as a way to mock "web components" or "custom elements" — those are different concepts that Rivets.js shouldn't care about, but should play well with in the future in that you should be able to write regular binders for them just as you would with any other element, but that's a whole other topic.

Here's what they look like in your templates.

``` html
<rv-chart type="bar" data="attendeeDistribution"></rv-chart>
```

They are also good way to add partial loading in your app.

``` html
<rv-partial ref="attendee/list" attendees="event.attendees"></rv-partial>
```

Components are defined as an object with two properties. `attributes` and `build`.

``` javascript
rivets.components.partial = {
  attributes: ["ref"],

  build: function() {
    return App.templates[this.ref]
  }
}
```
1. **attributes** is an array of attributes that you want to use internally while building the component view.
2. **build** is a function that returns the DOM template for the component view. Attributes defined on the `attributes` array will be available on `this` within the `build` function.

Any additional attributes set on the element that are not defined in the `attributes` array will get used for scope inflection. For example, let's say you are binding to `user.name` within the component's template, but you don't necessarily want `user` to be `user` from the parent view, you instead want `user` to be `session.speaker` from the parent view. All you need to do is add `user="session.speaker"` on the element and it will use that when binding the component view.

It's a very lightweight feature, but adds great flexibility and should alleviate a lot of duplication in your templates.
