### PR TITLE
Support binding to top level keys

### DIFF
--- a/spec/rivets/top_level_keys.js
+++ b/spec/rivets/top_level_keys.js
@@ -1,0 +1,35 @@
+describe('Rivets.Binding', function() {
+  var binding;
+
+  beforeEach(function() {
+    var el, view;
+
+    rivets.configure({
+      adapter: {
+        subscribe: function() {},
+        unsubscribe: function() {},
+        read: function() {},
+        publish: function() {}
+      }
+    });
+
+    el = document.createElement('div');
+    el.setAttribute('data-text', 'name');
+    view = rivets.bind(el, {name: 'dashkb'});
+    binding = view.bindings[0];
+  });
+
+  describe('bind()', function() {
+    it('can subscribe to top level keys on a model', function() {
+      spyOn(rivets.config.adapter, 'subscribe');
+      binding.bind();
+      expect(
+        rivets.config.adapter.subscribe
+      ).toHaveBeenCalledWith(
+        {name: 'dashkb'},
+        'name',
+        binding.sync
+      );
+    });
+  });
+});

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -36,7 +36,12 @@ class Rivets.Binding
     @binder or= @view.binders['*']
     @binder = {routine: @binder} if @binder instanceof Function
     @formatters = @options.formatters || []
-    @model = if @key then @view.models[@key] else @view.models
+
+    @model = if @key && @keypath != ''
+      @view.models[@key]
+    else
+      @keypath = @key if @keypath == ''
+      @view.models
 
   # Applies all the current formatters to the supplied value and returns the
   # formatted value.


### PR DESCRIPTION
So I noticed this right away and wanted to fix it:

HTML

``` html
<div id="broken">
  <input type="text" data-value="name"/>
</div>

<div id="works">
  <input type="text" data-value=".name"/>
</div>

<div id="also-works">
  <input type="text" data-value="model.name"/>
</div>
```

Coffee/jQ

``` coffee
model = {name: '@dashkb'}
rivets.bind ($ '#broken'), model
rivets.bind ($ '#works'), model
rivets.bind ($ '#also-works'), model: model
```

I am not sure how opinionated you want Rivets to be but seems to me all of the above cases should work.

Also the spec might belong someplace else; but I wanted to stick with your "do everything in the before hook" style.
