### PR TITLE
Use the correct context when calling formatters on models

### DIFF
--- a/spec/rivets/binding.js
+++ b/spec/rivets/binding.js
@@ -306,7 +306,10 @@ describe('Rivets.Binding', function() {
     });
 
     it('uses formatters on the model', function() {
-      model.modelAwesome = function(value) { return 'model awesome ' + value; };
+      model.modelAwesome = function(value) {
+        expect(this).toBe(model);
+        return 'model awesome ' + value;
+      };
       binding.formatters.push('modelAwesome');
       expect(binding.formattedValue('hat')).toBe('model awesome hat');
     });

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -46,7 +46,7 @@ class Rivets.Binding
       id = args.shift()
 
       formatter = if @model[id] instanceof Function
-        @model[id]
+        (args...) => @model[id](args...)
       else
         @view.formatters[id]
 
@@ -645,7 +645,7 @@ Rivets.binders =
 
     update: (models) ->
       data = {}
-      
+
       for key, model of models
         data[key] = model unless key is @args[0]
 


### PR DESCRIPTION
When using something like this:

``` html
<div data-text="model | toString"></model>
```

And the model has a function `toString` that method will be called with
the wrong context.

Here's an example of the problem: http://jsfiddle.net/HQJem/
