### PR TITLE
Polyfill for `Node` in IE <9

### DIFF
--- a/dist/rivets.js
+++ b/dist/rivets.js
@@ -20,7 +20,7 @@
     };
   }
 
-  if (typeof Node === void 0) {
+  if (typeof Node === 'undefined') {
     Node = {
       ELEMENT_NODE: 1,
       ATTRIBUTE_NODE: 2,

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -19,7 +19,7 @@ jQuery = window.jQuery or window.Zepto
 unless String::trim then String::trim = -> @replace /^\s+|\s+$/g, ''
 
 # Polyfill For `Node` in IE <9
-if typeof Node is undefined
+if typeof Node is 'undefined'
   Node =
     ELEMENT_NODE: 1
     ATTRIBUTE_NODE: 2


### PR DESCRIPTION
Fixes bug in IE8 and below, detailed in #190.

Solution should give the same effect as #192; happy for you to pick either solution for master.
