### PR TITLE
Pass local models into component build method

### DIFF
--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -166,8 +166,9 @@ class Rivets.ComponentBinding extends Rivets.Binding
     if @componentView?
       @componentView?.bind()
     else
-      el = @component.build.call @attributes
-      (@componentView = new Rivets.View(el, @locals(), @view.options)).bind()
+      locals = @locals()
+      el = @component.build.call @attributes, locals
+      (@componentView = new Rivets.View(el, locals, @view.options)).bind()
       @el.parentNode.replaceChild el, @el
 
   # Intercept `Rivets.Binding::unbind` to be called on `@componentView`.


### PR DESCRIPTION
This is useful when a component utilizes a dynamic property of a model. Example:

```
// Markup
<div id="my-view">
    <mycomponent car="thecar"></mycomponent>
</div>

// Component
rivets.components.mycomponent = {
    attributes: [],

    build: function(models) {
        var template = models.car.template; // 'my-template-key'
        return App.templates[template];
    }
};

// Car model
var car = {
    template: 'my-template-key'
};

// Bind the view
rivets.bind($('#my-view'), { thecar: car });
```

A more elegant approach might be to allow the attributes to be dynamic, but I didn't include an attempt at this in the pull request:

```
// Markup
<div id="my-view">
    <mycomponent template="thecar.template"></mycomponent>
</div>

// Component
rivets.components.mycomponent = {
    attributes: ['template'],

    build: function() {
        return App.templates[this.template];
    }
};

// Car model
var car = {
    template: 'my-template-key'
};

// Bind the view
rivets.bind($('#my-view'), { thecar: car });
```

My use case is a looped set of models where each model corresponds to a unique template.
