### PR TITLE
add support for paths wrapped in single-quotes along with tests

### DIFF
--- a/spec/rivets/keypath_parser.js
+++ b/spec/rivets/keypath_parser.js
@@ -1,0 +1,58 @@
+describe("Rivets.KeypathParser", function() {
+    var Rivets = rivets._,
+        interfaces = ['.', ':', ',', ';'],
+        parse = Rivets.KeypathParser.parse;
+
+    describe("parse()", function() {
+        it("uses the root interface for the first path", function() {
+            var path = keypath = "foo",
+                root = ":",
+                tokens = parse(keypath, interfaces, root);
+            expect(tokens.length).toEqual(1);
+            expect(tokens[0]).toEqual({interface: root, path: path});
+        });
+
+        it("supports single-char interfaces", function() {
+            var keypath = "foo.bar:baz,wut",
+                root = ".",
+                tokens = parse(keypath, interfaces, root);
+            expect(tokens.length).toEqual(4);
+            expect(tokens[0]).toEqual({interface: root, path: "foo"});
+            expect(tokens[1]).toEqual({interface: ".", path: "bar"});
+            expect(tokens[2]).toEqual({interface: ":", path: "baz"});
+            expect(tokens[3]).toEqual({interface: ",", path: "wut"});
+
+            keypath = "0.1.2.3.4.5.6";
+            tokens = parse(keypath, interfaces, root);
+            for (var i = 0; i < tokens.length; i ++) {
+                expect(tokens[i]).toEqual({interface: ".", path: i.toString()});
+            }
+        });
+
+        it("supports paths wrapped in single-quotes", function() {
+            var keypath = "foo.'bar:baz',wut",
+                root = ".",
+                tokens = parse(keypath, interfaces, root);
+            expect(tokens.length).toEqual(3);
+            expect(tokens[0]).toEqual({interface: root, path: "foo"});
+            expect(tokens[1]).toEqual({interface: ".", path: "bar:baz"});
+            expect(tokens[2]).toEqual({interface: ",", path: "wut"});
+
+            keypath = "'0'.'1.0'.'2.1.0'.'3.2.1.0'";
+            tokens = parse(keypath, interfaces, root);
+            var path;
+            for (var i = 0; i < tokens.length; i ++) {
+                path = i.toString();
+                for (var j = i - 1; j >= 0; j--) {
+                    path += "." + j;
+                }
+                expect(tokens[i]).toEqual({interface: ".", path: path});
+            }
+
+            keypath = "'obj'";
+            tokens = parse(keypath, interfaces, root);
+            expect(tokens.length).toEqual(1);
+            expect(tokens[0]).toEqual({interface: root, path: "obj"});
+        });
+    });
+});

--- a/src/parsers.coffee
+++ b/src/parsers.coffee
@@ -6,16 +6,22 @@ class Rivets.KeypathParser
   # Parses the keypath and returns a set of adapter interface + path tokens.
   @parse: (keypath, interfaces, root) ->
     tokens = []
-    current = {interface: root, path: ''}
 
-    for index, char of keypath
-      if char in interfaces
-        tokens.push current
-        current = {interface: char, path: ''}
-      else
-        current.path += char
+    # construct regex from interfaces
+    splitChars = interfaces.join('')
+    splits = '[' + splitChars + ']'
+    word = '[^' + splitChars + "']"
+    path = "(?:'(.+?)'|(" + word + '+))'
+    firstPathRegex = new RegExp('^' + path)
+    subsequentPathRegex = new RegExp("(" + splits + ")" + path, 'g')
 
-    tokens.push current
+    match = firstPathRegex.exec(keypath)
+    if match
+      tokens.push({interface: root, path: match[1] || match[2]})
+
+    while (match = subsequentPathRegex.exec(keypath)) != null
+      tokens.push({interface: match[1], path: match[2] || match[3]})
+
     tokens
 
 # Rivets.TextTemplateParser


### PR DESCRIPTION
Wanted to get the ball rolling on supporting wrapped paths, as discussed in #178 and requested in https://github.com/mikeric/rivets/issues/178#issuecomment-27847371

Wrapped paths are useful when the path passed to the adapter contains characters that could be misinterpreted as an adapter, such as backbone deep model.

```
<div>{ model:'sub.prop' }</div>

model.get('sub.prop') // should be this
model.get('sub').prop // not this
model.get("'sub")["prop'"] // nor this
```

The implementation is fairly flexible. We can use different wrapping delimeters (allow user to define it?). Using a regex to parse also opens the door to supporting multi-char adapters (e.g. `->`).
