### PR TITLE
Value binder overwrites value with true/false when used on checkboxes

### DIFF
--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -61,9 +61,9 @@ Rivets.binders.unchecked =
 Rivets.binders.value =
   publishes: true
   bind: (el) ->
-    Rivets.Util.bindEvent el, 'change', @publish
+    Rivets.Util.bindEvent el, 'change', @publish unless el.type is 'checkbox' or el.type is 'radio'
   unbind: (el) ->
-    Rivets.Util.unbindEvent el, 'change', @publish
+    Rivets.Util.unbindEvent el, 'change', @publish unless el.type is 'checkbox' or el.type is 'radio'
   routine: (el, value) ->
     if window.jQuery?
       el = jQuery el


### PR DESCRIPTION
Given a checkbox that has a value and has the value-binder applied to it:

```
<input type='checkbox' rv-value='item.name' rv-checked='item.buyme'>
```

When the checkbox is clicked, the value of the associated model is overwritten to true (in this case, `item.price` is set to true). This is because Rivets.Util.getInputValue() has a special case for checkboxes to return the value of "checked", then when the value binder gets the value of the input it returns true, and the value of the checkbox is overwritten with true. (In this case, `item.buyme` is also updated to true)

I think that the value binder should have a special case for checkboxes, where is should not bind or unbind to the value of a checkbox. Using the value binder is useful to set the value of a checkbox, but updating the value (based on the checked value of the input) does not make sense (so far as I can tell), because of the special meaning of value for checkboxes (and also radio buttons).
