### PR TITLE
Improved the performance of bindEvent, unbindEvent, getInputValue

### DIFF
--- a/src/util.coffee
+++ b/src/util.coffee
@@ -1,40 +1,30 @@
 # Rivets.Util
 # -----------
 
-# Houses common utility functions used internally by Rivets.js.
-Rivets.Util =
-  # Create a single DOM event binding.
-  bindEvent: (el, event, handler) ->
-    if window.jQuery?
-      el = jQuery el
-      if el.on? then el.on event, handler else el.bind event, handler
-    else if window.addEventListener?
-      el.addEventListener event, handler, false
-    else
-      event = 'on' + event
-      el.attachEvent event, handler
+if 'jQuery' of window
+  [bindMethod, unbindMethod] = if 'on' of jQuery then ['on', 'off'] else ['bind', 'unbind']
+  
+  Rivets.Util =
+    bindEvent: (el, event, handler) -> jQuery(el)[bindMethod] event, handler
+    unbindEvent: (el, event, handler) -> jQuery(el)[unbindMethod] event, handler
+    getInputValue: (el) ->
+      $el = jQuery el
 
-  # Remove a single DOM event binding.
-  unbindEvent: (el, event, handler) ->
-    if window.jQuery?
-      el = jQuery el
-      if el.off? then el.off event, handler else el.unbind event, handler
-    else if window.removeEventListener?
-      el.removeEventListener event, handler, false
-    else
-      event = 'on' + event
-      el.detachEvent  event, handler
+      if $el.attr('type') is 'checkbox' then $el.is ':checked'
+      else do $el.val
+else
+  Rivets.Util =
+    bindEvent: do ->
+      if 'addEventListener' of window then return (el, event, handler) ->
+        el.addEventListener event, handler, false
 
-  # Get the current value of an input node.
-  getInputValue: (el) ->
-    if window.jQuery?
-      el = jQuery el
-
-      switch el[0].type
-        when 'checkbox' then el.is ':checked'
-        else el.val()
-    else
-      switch el.type
-        when 'checkbox' then el.checked
-        when 'select-multiple' then o.value for o in el when o.selected
-        else el.value
+      (el, event, handler) -> el.attachEvent 'on' + event, handler
+    unbindEvent: do ->
+      if 'removeEventListener' of window then return (el, event, handler) ->
+        el.removeEventListener event, handler, false
+      
+      (el, event, handler) -> el.detachEvent 'on' + event, handler
+    getInputValue: (el) ->
+      if el.type is 'checkbox' then el.checked
+      else if el.type is 'select-multiple' then o.value for o in el when o.selected
+      else el.value


### PR DESCRIPTION
I'm improved the performance in Rivets.Util.

Instead of doing if statements in thouse methods it's better to just do them once and the then assign the right method.

I've even noticed some performance gains on the test suites... :) 
