### PR TITLE
Faster TextTemplateParser [Chrome]

### DIFF
--- a/src/parsers.coffee
+++ b/src/parsers.coffee
@@ -8,7 +8,8 @@ class Rivets.KeypathParser
     tokens = []
     current = {interface: root, path: ''}
 
-    for char in keypath
+    for index in [0...keypath.length] by 1
+      char = keypath.charAt index
       if char in interfaces
         tokens.push current
         current = {interface: char, path: ''}


### PR DESCRIPTION
I was playing with RegEx so i tried to come up with a RegEx way of
handling the TextTemplate in Rivets. And (at least in Chrome) the
solution is nearly twice as fast.

You can find the perf test here: http://jsperf.com/parse-string-regex

It’s is quite astonishing how much better V8 can handle regular
expressions.

If other browser catch up with the RegEx performance this could be a better solution. 
