### PR TITLE
Adding charAt in keypath parse instead of array operator

### DIFF
--- a/src/parsers.coffee
+++ b/src/parsers.coffee
@@ -8,7 +8,8 @@ class Rivets.KeypathParser
     tokens = []
     current = {interface: root, path: ''}
 
-    for char in keypath
+    for index in [0...keypath.length] by 1
+      char = keypath.charAt index
       if char in interfaces
         tokens.push current
         current = {interface: char, path: ''}


### PR DESCRIPTION
Some older browsers dont support the array operator when iterating through strings, so using charAt is more suitable.  Simple hello world test page can be found here http://softgpl.com/rivets/ie7/index.html

Issue https://github.com/mikeric/rivets/issues/246
