### PR TITLE
update gruntfile for building to coffeescript

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,6 +29,7 @@ module.exports = (grunt) ->
       all:
         options:
           join: true
+          sourceMap: true
         files:
           'dist/rivets.js': '<%= config.coffeeFiles %>'
 


### PR DESCRIPTION
This adds to the Gruntfile the ability to build the full source as CoffeeScript, for environments that are able to execute CoffeeScript directly. Makes it easier to debug Rivets errors in these environments.
