### PR TITLE
allow to locally null adapter

### DIFF
--- a/src/observer.coffee
+++ b/src/observer.coffee
@@ -12,7 +12,7 @@ class Rivets.Observer
   # Parses the keypath using the interfaces defined on the view. Sets variables
   # for the tokenized keypath, as well as the end key.
   parse: =>
-    interfaces = (k for k, v of @view.adapters)
+    interfaces = (k for k, v of @view.adapters when v)
 
     if @keypath[0] in interfaces
       root = @keypath[0]


### PR DESCRIPTION
This will allow to remove global adapter locally.

``` javascript
rivets.bind(el, model, {
  adapters: {
    '.': false
  }
});
```

I needed it because I have paths like `a.b.c/value`. It will also help if you have another global adapter like `-`.
