### PR TITLE
Make each-* routine compatible with collections

### DIFF
--- a/spec/rivets/functional.js
+++ b/spec/rivets/functional.js
@@ -232,6 +232,15 @@ describe('Functional', function() {
         data.set({items: collection});
         expect(el.textContent).toBe('edcba');
       });
+
+      it('should replace all bound elements to match the new collection and sort them according to order of items in the collection', function () {
+        listItem.setAttribute('data-text', 'item.name');
+        rivets.bind(el, bindData);
+        expect(el.textContent).toBe('ab');
+        data.set({items: [{name: 'e'}, {name: 'p'}, {name: 'r'}]});
+        expect(el.getElementsByTagName('li').length).toBe(3);
+        expect(el.textContent).toBe('epr');
+      });
     });
   });
 

--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -199,7 +199,7 @@ Rivets.binders['each-*'] =
           data[key] ?= view_model
 
         previous = if index and @iterated.length
-          if index - 1 in @iterated
+          if @iterated[index - 1]
             @iterated[index - 1].els[0]
           else
             @iterated[@iterated.length - 1].els[0]


### PR DESCRIPTION
Current implementation overwrites objects in-place, so when another object (e.g. a UI component) references the object in the collection that's overwritten discrepancies start to appear between the state of that component and the object (model) in the collection it's referencing.

This implementation maintains the original objects while keeping the correct state and same index order of collection and DOM elements.

This means that the each-\* routine can now be safely used with Backbone.js/Spine.js/etc collections and therefore, Rivets.js can become a genuine part of any SPA stack.

This implementation has been tested in a stack using Backbone.js and supports listening to the `add`, `remove` and `sort` events of Backbone's collections, with UI components referencing both the collection and each of its models.

~Y
