### PR TITLE
Grunt should watch all rivets sources

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -50,7 +50,7 @@ module.exports = (grunt) ->
 
     watch:
       all:
-        files: 'src/rivets.coffee'
+        files: 'src/*.coffee'
         tasks: ['build', 'spec']
 
   grunt.loadNpmTasks 'grunt-contrib-coffee'


### PR DESCRIPTION
Now, grunt's "watch" task works only with rivets.coffee
