### PR TITLE
Fix: each-*: when rebinding, bind any existing views in @iterated

### DIFF
--- a/spec/rivets/binders.js
+++ b/spec/rivets/binders.js
@@ -30,4 +30,73 @@ describe("Rivets.binders", function() {
       rivets.binders.value.unbind.call(context, el)
     })
   })
-})
+
+  describe("each-*", function() {
+    var fragment;
+    var el;
+    var model;
+
+    beforeEach(function() {
+      fragment = document.createDocumentFragment();
+      el = document.createElement("li");
+      el.setAttribute("rv-each-item", "items");
+      el.setAttribute("rv-text", "item.val");
+
+      fragment.appendChild(el);
+
+      model = { items: [{val: 0},{val: 1},{val: 2}] };
+    });
+
+    it("binds to the model creating a list item for each element in items", function() {
+      var view = rivets.bind(fragment, model);
+
+      // one child for each element in the model plus 1 for the comment placeholder
+      Should(fragment.childNodes.length).be.exactly(model.items.length + 1);
+    });
+
+    it("reflects changes to the model into the DOM", function() {
+      var view = rivets.bind(fragment, model);
+      Should(fragment.childNodes[1].innerText).be.exactly("0");
+
+      model.items[0].val = "howdy";
+      Should(fragment.childNodes[1].innerText).be.exactly("howdy");
+    });
+
+    it("reflects changes to the model into the DOM after unbind/bind", function() {
+      var view = rivets.bind(fragment, model);
+      Should(fragment.childNodes[1].innerText).be.exactly("0");
+
+      view.unbind();
+      view.bind();
+      model.items[0].val = "howdy";
+      Should(fragment.childNodes[1].innerText).be.exactly("howdy");
+    });
+
+    it("lets you push an item", function() {
+      var view = rivets.bind(fragment, model);
+      var originalLength  = model.items.length;
+
+      // one child for each element in the model plus 1 for the comment placeholder
+      Should(fragment.childNodes.length).be.exactly(model.items.length + 1);
+
+      model.items.push({val: 3});
+      Should(model.items.length).be.exactly(originalLength + 1);
+      Should(fragment.childNodes.length).be.exactly(model.items.length + 1);
+    });
+
+    it("lets you push an item after unbind/bind", function() {
+      var view = rivets.bind(fragment, model);
+      var originalLength  = model.items.length;
+
+      // one child for each element in the model plus 1 for the comment placeholder
+      Should(fragment.childNodes.length).be.exactly(model.items.length + 1);
+
+      view.unbind();
+      view.bind();
+
+      model.items.push({val: 3});
+      Should(model.items.length).be.exactly(originalLength + 1);
+      Should(fragment.childNodes.length).be.exactly(model.items.length + 1);
+    });
+  });
+});

--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -157,6 +157,10 @@ Rivets.binders['each-*'] =
       el.removeAttribute attr
       el.parentNode.insertBefore @marker, el
       el.parentNode.removeChild el
+    else
+      for view in @iterated
+        view.bind()
+    return;
 
   unbind: (el) ->
     view.unbind() for view in @iterated if @iterated?


### PR DESCRIPTION
Prior to this change, an each-\* bound view could be rebound but only at the array level.  i.e.: any existing views that had been realized weren’t being bound again.  This let you realize changes to the array itself, but changes to existing elements of the array were not being reflected into the DOM.

I've also added a few tests around some of the each-\* binder - hopefully in location you would have expected.

I should also mention that, while I drink coffee, I don't write it - hopefully I've fumbled my way the correct solution here.
