### PR TITLE
prevent execution/failure of obsolete callbacks

### DIFF
--- a/src/adapters.coffee
+++ b/src/adapters.coffee
@@ -62,7 +62,7 @@ Rivets.adapters['.'] =
         set: (newValue) =>
           if newValue isnt value
             value = newValue
-            callback() for callback in callbacks[keypath]
+            callback() for callback in callbacks[keypath].slice() when callback in callbacks[keypath]
             @observeMutations newValue, obj[@id], keypath
 
     unless callback in callbacks[keypath]


### PR DESCRIPTION
callback() can modifie callbacks[keypath]
This will lead to an exception when callbacks unsubscribe other callbacks.
demo: http://jsfiddle.net/hpUTB/
