### PR TITLE
Add a DOM element binder (rv-el)

### DIFF
--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -26,6 +26,11 @@ Rivets.binders.enabled = (el, value) ->
 # Disables the element when value is true (negated version of `enabled` binder).
 Rivets.binders.disabled = (el, value) ->
   el.disabled = !!value
+  
+# Sets the element's child element
+rivets.binders.el = (el, value) ->
+  el.innerHTML = ''
+  el.appendChild(value) if value?.nodeName?
 
 # Checks a checkbox or radio input when the value is true. Also sets the model
 # property when the input is checked or unchecked (two-way binder).


### PR DESCRIPTION
This change adds the rv-el binder to rivets, which will bind a DOM element to the element. Rivets' rv-html does not do this, and stringifies passed DOM elements.
