### PR TITLE
Fix each-binder when using custom adapters

### DIFF
--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -109,7 +109,9 @@ class Rivets.Binding
   # the old model first and then re-binds with the new model.
   update: (models = {}) =>
     @model = @observer.target
+    @unbind()
     @binder.update?.call @, models
+    @bind()
 
 # Rivets.ComponentBinding
 # -----------------------


### PR DESCRIPTION
I just added a call to `unbind()` and `bind()` as described in the method's annotation. The `bind()` call is necessary to sync the binding with the updated model.

See also #295 and http://jsfiddle.net/bFNTp/
