### PR TITLE
feat(bindings): allow access to component element in build function

### DIFF
--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -157,7 +157,7 @@ class Rivets.ComponentBinding extends Rivets.Binding
     if @componentView?
       @componentView?.bind()
     else
-      el = @component.build.call @attributes
+      el = @component.build.call @attributes @el
       (@componentView = new Rivets.View(el, @locals(), @view.options)).bind()
       @el.parentNode.replaceChild el, @el
 


### PR DESCRIPTION
This small addition passes the element of the component to the build function. This would give the ability to retrieve HTML inside the component and use it in the template. This is SIMILAR (but not the same) to AngularJS transclusions.
