### PR TITLE
Remove reserved word

### DIFF
--- a/src/parsers.coffee
+++ b/src/parsers.coffee
@@ -9,12 +9,12 @@ class Rivets.KeypathParser
     current = {interface: root, path: ''}
 
     for index in [0...keypath.length] by 1
-      char = keypath.charAt index
-      if char in interfaces
+      chr = keypath.charAt index
+      if chr in interfaces
         tokens.push current
-        current = {interface: char, path: ''}
+        current = {interface: chr, path: ''}
       else
-        current.path += char
+        current.path += chr
 
     tokens.push current
     tokens


### PR DESCRIPTION
The code compiles into JavaScript with a [reserved word](http://www.w3schools.com/js/js_reserved.asp) `char`. Not sure why CoffeeScript compiler doesn't catch that, anyway, it makes YUI compressor fail:

```
'/usr/bin/java' '-jar' app/Resources/java/yuicompressor-2.4.7.jar '--charset' 'UTF-8' '-o' '/tmp/rivets' '--type' 'js' 'src/Resources/public/js/libs/rivets.js'

[ERROR] 125:15:missing variable name

[ERROR] 132:13:identifier is a reserved word

[ERROR] 133:44:identifier is a reserved word

[ERROR] 134:18:syntax error

[ERROR] 136:30:identifier is a reserved word

[ERROR] 137:18:syntax error

[ERROR] 139:15:syntax error

[ERROR] 140:19:syntax error

[ERROR] 143:13:missing ) in parenthetical

[ERROR] 143:14:syntax error

[ERROR] 145:6:missing ) in parenthetical

[ERROR] 147:11:invalid return

[ERROR] 149:3:syntax error

[ERROR] 1247:1:syntax error

[ERROR] 1:0:Compilation produced 14 syntax errors.
org.mozilla.javascript.EvaluatorException: Compilation produced 14 syntax errors.
```

I renamed `char` to `chr`
