### PR TITLE
this.model avaibility

### DIFF
--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -120,8 +120,8 @@ class Rivets.Binding
   # routines will also listen for changes on the element to propagate them back
   # to the model.
   bind: =>
-    @binder.bind?.call @, @el
     @parseTarget()
+    @binder.bind?.call @, @el
 
     if @model? and @options.dependencies?.length
       for dependency in @options.dependencies


### PR DESCRIPTION
This PR makes `this.model` available asap to the binders.bind method, relates to #285 

Could not figure out how to add a new test.

We need binders api tests, which means accessing only public properties:

``` js
describe('adding a binder', function() {
  var binder, model, el;

  beforeEach(function(){
    binder = {};
    model = {
      prop: 'val'
    }
    rivets.binders.custom = binder;
  });

  it('calls .bind', function() {
    // ...
  })

  it('fills this.model inside bind', function() {
    binder.bind = function() {
      this.model.should.be.an.instanceOf(Object)
      // ...
    }

    rivets.bind(el, model)
  })
});
```

Right now I feel the tests are too deeply linked to the code, we should only test which API rivets wants to expose to the public, not private things like `binder.binding.view....`

Maybe I am wrong.

What do you think @mikeric?
