### PR TITLE
added Binding.getValue(el) using it in Binder.publish()

### DIFF
--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -153,7 +153,10 @@ class Rivets.Binding
     
   # Returns elements value
   getValue: (el) =>
-    (@binder.getValue.bind(@) or Rivets.Util.getInputValue) el
+    if @binder.getValue
+      @binder.getValue.call @, el
+      
+    Rivets.Util.getInputValue el
 
 # Rivets.ComponentBinding
 # -----------------------


### PR DESCRIPTION
This way binders can override the value returned when publishing. Usefull for custom binders that retrieve theire data from something else then the elements input value.
