### PR TITLE
Use prototype inheritance in each-binder

### DIFF
--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -189,12 +189,11 @@ Rivets.public.binders['each-*'] =
         @marker.parentNode.removeChild view.els[0]
 
     for model, index in collection
-      data = {index}
+      data = Object.create @view.models
+      data.index = index
       data[modelName] = model
 
       if not @iterated[index]?
-        for key, model of @view.models
-          data[key] ?= model
 
         previous = if @iterated.length
           @iterated[@iterated.length - 1].els[0]


### PR DESCRIPTION
This fixes a problem where arrays and objects where not updated inside the each-binding.

I've created a JSFiddle to demonstrate the problem: http://jsfiddle.net/hnodsc7n/1/
When the `items`-array is changed, the each-binding still holds a reference to the old `items`-array. This is because rivets just copies the properties from one model to another. However, this fix uses prototype inheritance. Thus every change on the super-model is propagated to the sub-model. Check out the difference: http://jsfiddle.net/znv28cmj/1/

There are two potential problems with this fix:
- I'm using `Object.create()` which is not available in IE8. However, there is a polyfill for it (which I haven't included because imho libraries shouldn't bring their own polyfills).
- If someone is iterating over the sub-model and checks for `if (obj.hasOwnProperty(key))` it will not iterate over all properties anymore.

All tests are running
