### PR TITLE
Fix memory leak in weakmap

### DIFF
--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -15,7 +15,7 @@ Rivets.public.adapters['.'] =
 
   cleanupWeakReference: (ref, id) ->
     unless Object.keys(ref.callbacks).length
-      unless Object.keys(ref.pointers).length
+      unless ref.pointers and Object.keys(ref.pointers).length
         delete @weakmap[id]
 
   stubFunction: (obj, fn) ->


### PR DESCRIPTION
Removes weak referenced objects when there are no more callbacks / pointers left for the object in question. The following heap timeline was recorded with the same sample code used by @tcz to demonstrate memory leaks in #369.

![screen shot 2014-11-12 at 8 24 33 pm](https://cloud.githubusercontent.com/assets/36068/5023308/1d13cf46-6aaa-11e4-9c40-3c9576620d2e.png)
#369, #392
