### PR TITLE
Event handling: Use binding model as context

### DIFF
--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -74,7 +74,7 @@ class Rivets.Binding
   # Returns an event handler for the binding around the supplied function.
   eventHandler: (fn) =>
     handler = (binding = @).view.handler
-    (ev) -> handler.call fn, @, ev, binding
+    (ev) -> handler.call fn, binding.model, ev, binding
 
   # Sets the value for the binding. This Basically just runs the binding routine
   # with the suplied value formatted.


### PR DESCRIPTION
This is more of a question than it is a pull request. I've just started playing with rivets, it's working pretty great. There is one thing that 'feels' a bit odd, it's the context of a function that is called within events. Let me explain:

**Current situation**

```html
<a rv-on-click="toggle">Toggle me</a>
<div rv-show="open">Information</div>
```

```coffee
class SomeInterface
  toggle: (event, context) ->
    @open = !@open # This doesn't work because we're not in the right context
    context.model.open = !context.model.open
```

**Situation in this pull request**

Given the same HTML as above.

```coffee
class SomeInterface
  toggle: (event, context) ->
    @open = !@open
```
---
Is this on purpose, am I missing something? Or am I simply doing something wrong? Would love to get some feedback.