### PR TITLE
Fix ensure .init() can handle jquery objects

### DIFF
--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -66,6 +66,7 @@ Rivets =
     # returns a Rivets.View instance.
     init: (component, el, data = {}) ->
       el ?= document.createElement 'div'
+      el =  if el instanceof jQuery then el[0]
       component = Rivets.public.components[component]
       el.innerHTML = component.template.call @, el
       scope = component.initialize.call @, el, data


### PR DESCRIPTION
Fixes #461 

Not really sure how I should make a test case for this because it involves including jQuery. I can just create a pseudo class called jQuery but I'm not sure if that's adequate. 