### PR TITLE
Added regexp to split formatters

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -34,7 +34,7 @@ class Rivets.View
   buildBinding: (binding, node, type, declaration) =>
     options = {}
 
-    pipes = (pipe.trim() for pipe in declaration.split '|')
+    pipes = (pipe.trim() for pipe in declaration.match /((?:'[^']*')*(?:(?:[^\|']+(?:'[^']*')*[^\|']*)+|[^\|]+))|^$/g)
     context = (ctx.trim() for ctx in pipes.shift().split '<')
     keypath = context.shift()
 


### PR DESCRIPTION
The regexp allows pipes in quoted arguments. Fixes #432

Ex : { model | append 'i can have pipes || here' }