### PR TITLE
Added 'updateEvent' configuration for overriding default oninput even

### DIFF
--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -72,7 +72,7 @@ Rivets.public.binders.value =
 
   bind: (el) ->
     unless el.tagName is 'INPUT' and el.type is 'radio'
-      @event = if el.tagName is 'SELECT' then 'change' else 'input'
+      @event = if el.tagName is 'SELECT' then 'change' else Rivets.public.updateEvent
       Rivets.Util.bindEvent el, @event, @publish
 
   unbind: (el) ->

--- a/src/rivets.coffee
+++ b/src/rivets.coffee
@@ -6,6 +6,7 @@ Rivets =
     'rootInterface'
     'preloadData'
     'handler'
+    'updateEvent'
   ]
 
   extensions: [
@@ -40,6 +41,9 @@ Rivets =
 
     # Preload data by default.
     preloadData: true
+
+    # Use the 'oninput' event by default so synchronization occurs as changes occur.
+    updateEvent: 'input'
 
     # Default event handler.
     handler: (context, ev, binding) ->


### PR DESCRIPTION
I needed a way to overwrite the default use of "oninput" for changes in my app. We still support some legacy browsers and need to use the "change" event.

Besides, in some cases you may not want to use the "input" event, but instead use change as the default behavior.

This pull request gives you a new "updateEvent" configuration option in which you can change the behavior.