### PR TITLE
Use textContent instead of innerText in spec

### DIFF
--- a/spec/rivets/binders.js
+++ b/spec/rivets/binders.js
@@ -56,20 +56,20 @@ describe("Rivets.binders", function() {
 
     it("reflects changes to the model into the DOM", function() {
       var view = rivets.bind(fragment, model);
-      Should(fragment.childNodes[1].innerText).be.exactly("0");
+      Should(fragment.childNodes[1].textContent).be.exactly("0");
 
       model.items[0].val = "howdy";
-      Should(fragment.childNodes[1].innerText).be.exactly("howdy");
+      Should(fragment.childNodes[1].textContent).be.exactly("howdy");
     });
 
     it("reflects changes to the model into the DOM after unbind/bind", function() {
       var view = rivets.bind(fragment, model);
-      Should(fragment.childNodes[1].innerText).be.exactly("0");
+      Should(fragment.childNodes[1].textContent).be.exactly("0");
 
       view.unbind();
       view.bind();
       model.items[0].val = "howdy";
-      Should(fragment.childNodes[1].innerText).be.exactly("howdy");
+      Should(fragment.childNodes[1].textContent).be.exactly("howdy");
     });
 
     it("lets you pop an item", function() {


### PR DESCRIPTION
textContent is a standard compliant property, implemented in all modern browsers, while innerText is not. Firefox e.g. does not implements it

With this PR the spec runs fine with Firefox and also IE11, Edge, Opera, Chrome, PhantomJS

PR from an dedicated branch instead of es6, unlike previous one
