### PR TITLE
Update build and test configuration (ES6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "pretest": "babel src/parsers.js --out-file spec/lib/parsers.js --modules umd",
     "test": "mocha-phantomjs spec/runner.html",
-    "build": "webpack && webpack -p"
+    "build": "webpack --x-minimize --x-standalone && webpack --x-minimize"
   },
   "devDependencies": {
     "babel-core": "^4.7.16",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sightglass": "~0.2.4"
   },
   "scripts": {
-    "pretest": "babel src/parsers.js --out-file spec/lib/parsers.js --modules umd",
+    "pretest": "webpack --config=webpack.spec.config.js",
     "test": "mocha-phantomjs spec/runner.html",
     "build": "webpack --x-minimize --x-standalone && webpack --x-minimize"
   },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "devDependencies": {
     "babel-core": "^4.7.16",
-    "babel-loader": "^4.2.0",
-    "minimist": "~1.1.0",
+    "babel-loader": "^4.2.0",    
     "mocha": "~1.20.1",
     "should": "~4.0.4",
     "sinon": "~1.10.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "pretest": "babel src/parsers.js --out-file spec/lib/parsers.js --modules umd",
     "test": "mocha-phantomjs spec/runner.html",
-    "build": "webpack"
+    "build": "webpack && webpack -p"
   },
   "devDependencies": {
     "babel-core": "^4.7.16",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "mocha": "~1.20.1",
     "should": "~4.0.4",
     "sinon": "~1.10.2",
-    "webpack": "^1.7.3"
+    "webpack": "^1.7.3",
+    "mocha-phantomjs": "^3.6.0",
+    "phantomjs": "1.9.7-15"	
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,16 +1,30 @@
 var webpack = require('webpack');
-var minimize = process.argv.indexOf('-p') === -1 ? false : true;
+//options
+var minimize = process.argv.indexOf('--x-minimize') !== -1;
+var standalone = process.argv.indexOf('--x-standalone') !== -1;
+
+var entryKeys = standalone ? ['rivets'] : ['rivets.bundled'];
+
+var entry = entryKeys.reduce(function (memo, key) {
+  memo[key] = './src/export';
+  if (minimize) {
+    memo[key + '.min'] = './src/export';
+  }
+  return memo;
+}, {});
 
 module.exports = {
   context: __dirname,
-  entry: './src/export',
+  entry: entry,
 
   output: {
     path: __dirname + '/dist',
-    filename: 'rivets.bundled' + (minimize ? '.min.' : '.') + 'js',
+    filename: '[name].js',
     library: 'rivets',
     libraryTarget: 'umd'
   },
+
+  externals: standalone ? ['sightglass'] : undefined,
 
   module: {
     loaders: [
@@ -22,7 +36,13 @@ module.exports = {
     ]
   },
 
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin({
+      include: /\.min\.js$/
+    })
+  ],
+
   resolve: {
     extensions: ['', '.js']
   }
-}
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
-var webpack = require('webpack')
+var webpack = require('webpack');
+var minimize = process.argv.indexOf('-p') === -1 ? false : true;
 
 module.exports = {
   context: __dirname,
@@ -6,7 +7,7 @@ module.exports = {
 
   output: {
     path: __dirname + '/dist',
-    filename: 'rivets.bundled.js',
+    filename: 'rivets.bundled' + (minimize ? '.min.' : '.') + 'js',
     library: 'rivets',
     libraryTarget: 'umd'
   },

--- a/webpack.spec.config.js
+++ b/webpack.spec.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  context: __dirname,
+  entry: "./src/parsers",
+  output: {
+    path: __dirname + "/spec/lib",
+    filename: "parsers.js",
+    library: 'parsers',
+    libraryTarget: 'umd'
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: '/node_modules/',
+        loader: 'babel-loader'
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR updates the configuration in ES6 branch:
- implement minified and standalone builds
- add configuration to build parsers (needed to test) using webpack
- Remove unused minimist dependency
- Add dependency to phantomjs / mocha-phantomjs

Executing `npm run build` will build rivets.js, rivets.min.js, rivets.bundled.js and rivets.bundled.min.js
Executing webpack will build rivets.bundled.js
No need to have babel or phantomjs installed globally
