### PR TITLE
Don't use view.els.forEach to avoid exception when jquery is used

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -117,7 +117,10 @@ export default class View {
       }
     }
 
-    this.els.forEach(parse)
+    let elements = this.els, i, len;
+    for (i = 0, len = elements.length; i < len; i++) {
+      parse(elements[i])
+    }
 
     this.bindings.sort((a, b) => {
       let aPriority = defined(a.binder) ? (a.binder.priority || 0) : 0


### PR DESCRIPTION
An `Uncaught TypeError: this.els.forEach is not a function` exception occurs when creating a view with jQuery like:
`view = rivets.bind($('#list'), {items: data});`