### PR TITLE
Add non minified bundled target to build script (Coffee)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,12 @@ gulp.task('build', function() {
       .pipe(uglify())
       .pipe(concat('rivets.bundled.min.js'))
       .pipe(header(banner(true)))
-      .pipe(gulp.dest('dist'))
+      .pipe(gulp.dest('dist'));
+	  
+	gulp.src([sightglass, rivets])      
+      .pipe(concat('rivets.bundled.js'))
+      .pipe(header(banner(true)))
+      .pipe(gulp.dest('dist'));  
   })
 })
 


### PR DESCRIPTION
It creates rivets.bundled.js. Useful to compare generated code / profile against es6 build