### PR TITLE
Change variable name in adapter.observe to avoid argument capture into closure 

### DIFF
--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -77,7 +77,7 @@ Rivets.public.adapters['.'] =
                 callbacks = map.callbacks
 
                 if callbacks[keypath]
-                  callback() for callback in callbacks[keypath].slice() when callback in callbacks[keypath]
+                  cb() for cb in callbacks[keypath]
                 @observeMutations newValue, obj[@id], keypath
 
     unless callback in callbacks[keypath]


### PR DESCRIPTION
In the default adapter `observe` method the callback argument is accidentally captured into the closure. This can lead to memory leaks in situations as simple as http://codepen.io/blikblum/pen/BjYPgo

The PR also removes an redundant check in the loop

With this and https://github.com/mikeric/sightglass/pull/13 most of the leaks found in the TodoMVC example ( https://github.com/tastejs/todomvc/pull/1295 ) are resolved.

Some  leaks still remains, which i'm looking at      

@mikeric @Leeds-eBooks