### PR TITLE
Avoid creation of needless temporary arrays

### DIFF
--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -181,6 +181,7 @@ Rivets.public.binders['each-*'] =
 
   unbind: (el) ->
     view.unbind() for view in @iterated if @iterated?
+    return
 
   routine: (el, collection) ->
     modelName = @args[0]
@@ -221,6 +222,7 @@ Rivets.public.binders['each-*'] =
       for binding in @view.bindings
         if binding.el is @marker.parentNode and binding.type is 'value'
           binding.sync()
+    return
 
   update: (models) ->
     data = {}
@@ -229,6 +231,7 @@ Rivets.public.binders['each-*'] =
       data[key] = model unless key is @args[0]
 
     view.update data for view in @iterated
+    return
 
 # Adds or removes the class from the element when value is true or false.
 Rivets.public.binders['class-*'] = (el, value) ->

--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -246,6 +246,7 @@ class Rivets.ComponentBinding extends Rivets.Binding
         @upstreamObservers[key] = @observe @componentView.models, key, ((key, observer) => =>
           observer.setValue @componentView.models[key]
         ).call(@, key, observer)
+    return
 
   # Intercept `Rivets.Binding::unbind` to be called on `@componentView`.
   unbind: =>

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -69,6 +69,7 @@ class Rivets.View
 
       unless block
         parse childNode for childNode in (n for n in node.childNodes)
+      return
 
     parse el for el in @els
 
@@ -119,20 +120,25 @@ class Rivets.View
   # Binds all of the current bindings for this view.
   bind: =>
     binding.bind() for binding in @bindings
+    return
 
   # Unbinds all of the current bindings for this view.
   unbind: =>
     binding.unbind() for binding in @bindings
+    return
 
   # Syncs up the view with the model by running the routines on all bindings.
   sync: =>
     binding.sync?() for binding in @bindings
+    return
 
   # Publishes the input values from the view back to the model (reverse sync).
   publish: =>
     binding.publish() for binding in @select (b) -> b.binder?.publishes
+    return
 
   # Updates the view's models along with any affected bindings.
   update: (models = {}) =>
     @models[key] = model for key, model of models
     binding.update? models for binding in @bindings
+    return


### PR DESCRIPTION
Due to how CoffeeScript works, a temporary array is being created to be returned in functions
Those are used nowhere increasing heap allocations with no benefits

As an example see the compiled View.bind method before and after the PR:
Before:
```
  View.prototype.bind = function() {
      var binding, _i, _len, _ref1, _results;
      _ref1 = this.bindings;
      _results = [];
      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
        binding = _ref1[_i];
        _results.push(binding.bind());
      }
      return _results;
    };
```
After:
```
  View.prototype.bind = function() {
      var binding, _i, _len, _ref1;
      _ref1 = this.bindings;
      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
        binding = _ref1[_i];
        binding.bind();
      }
    };
```