### PR TITLE
Added parsing for component attributes to handle constant strings 

### DIFF
--- a/spec/rivets/component_binding.js
+++ b/spec/rivets/component_binding.js
@@ -34,10 +34,16 @@ describe('Component binding', function() {
     })
 
     it('receives primitives attributes', function() {
-      componentRoot.setAttribute('primitive', "'value'")
+      componentRoot.setAttribute('primitivestring', "'value'")
+      componentRoot.setAttribute('primitivenumber', "42")
+      componentRoot.setAttribute('primitiveboolean', "true")
       rivets.bind(element, locals)
 
-      component.initialize.calledWith(componentRoot, { item: locals.object, primitive: 'value' }).should.be.true
+      component.initialize.calledWith(componentRoot, { item: locals.object,
+        primitivestring: 'value',
+        primitivenumber: 42,
+        primitiveboolean: true })
+      .should.be.true
     })
 
     it('returns attributes assigned to "static" property as they are', function() {

--- a/spec/rivets/component_binding.js
+++ b/spec/rivets/component_binding.js
@@ -1,0 +1,63 @@
+describe('Component binding', function() {
+  var scope, element, component, componentRoot
+
+  beforeEach(function() {
+    element = document.createElement('div')
+    element.innerHTML = '<test></test>'
+    componentRoot = element.firstChild
+    scope = { name: 'Rivets' }
+    component = rivets.components.test = {
+      initialize: sinon.stub().returns(scope),
+      template: function() {}
+    }
+  })
+
+  it('renders "template" as a string', function() {
+    rivets.components.test.template = function() {return '<h1>test</h1>'}
+    rivets.bind(element)
+
+    componentRoot.innerHTML.should.equal(component.template())
+  })
+
+  describe('initialize()', function() {
+    var locals
+
+    beforeEach(function() {
+      locals = { object: { name: 'Rivets locals' } }
+      componentRoot.setAttribute('item', 'object')
+    })
+
+    it('receives element as first argument and attributes as second', function() {
+      rivets.bind(element, locals)
+
+      component.initialize.calledWith(componentRoot, { item: locals.object }).should.be.true
+    })
+
+    it('receives primitives attributes', function() {
+      componentRoot.setAttribute('primitive', "'value'")
+      rivets.bind(element, locals)
+
+      component.initialize.calledWith(componentRoot, { item: locals.object, primitive: 'value' }).should.be.true
+    })
+
+    it('returns attributes assigned to "static" property as they are', function() {
+      var type = 'text'
+
+      component.static = ['type']
+      componentRoot.setAttribute('type', type)
+      rivets.bind(element, locals)
+
+      component.initialize.calledWith(componentRoot, { item: locals.object, type: type }).should.be.true
+    })
+  })
+
+  describe('when "template" is a function', function() {
+    it('renders returned string as component template', function() {
+      component.template = sinon.stub().returns('<h1>{ name }</h1>')
+      rivets.bind(element)
+
+      componentRoot.innerHTML.should.equal('<h1>' + scope.name + '</h1>')
+    })
+  })
+
+})

--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -176,8 +176,12 @@ class Rivets.ComponentBinding extends Rivets.Binding
       unless bindingRegExp.test attribute.name
         propertyName = @camelCase attribute.name
 
+        token = Rivets.TypeParser.parse(attribute.value)
+
         if propertyName in (@component.static ? [])
           @static[propertyName] = attribute.value
+        else if token.type is 0
+          @static[propertyName] = token.value
         else
           @observers[propertyName] = attribute.value
 


### PR DESCRIPTION
For backward compatibility reasons, i left the "static attribute" feature.
See issue #478 