### PR TITLE
Report for 'Constant string in component HTML attributes #478'. New t…

### DIFF
--- a/spec/rivets/component_binding.js
+++ b/spec/rivets/component_binding.js
@@ -1,0 +1,69 @@
+describe('Component binding', function() {
+  var scope, element, component, componentRoot
+
+  beforeEach(function() {
+    element = document.createElement('div')
+    element.innerHTML = '<test></test>'
+    componentRoot = element.firstChild
+    scope = { name: 'Rivets' }
+    component = rivets.components.test = {
+      initialize: sinon.stub().returns(scope),
+      template: function() {}
+    }
+  })
+
+  it('renders "template" as a string', function() {
+    rivets.components.test.template = function() {return '<h1>test</h1>'}
+    rivets.bind(element)
+
+    componentRoot.innerHTML.should.equal(component.template())
+  })
+
+  describe('initialize()', function() {
+    var locals
+
+    beforeEach(function() {
+      locals = { object: { name: 'Rivets locals' } }
+      componentRoot.setAttribute('item', 'object')
+    })
+
+    it('receives element as first argument and attributes as second', function() {
+      rivets.bind(element, locals)
+
+      component.initialize.calledWith(componentRoot, { item: locals.object }).should.be.true
+    })
+
+    it('receives primitives attributes', function() {
+      componentRoot.setAttribute('primitivestring', "'value'")
+      componentRoot.setAttribute('primitivenumber', "42")
+      componentRoot.setAttribute('primitiveboolean', "true")
+      rivets.bind(element, locals)
+
+      component.initialize.calledWith(componentRoot, { item: locals.object,
+        primitivestring: 'value',
+        primitivenumber: 42,
+        primitiveboolean: true })
+      .should.be.true
+    })
+
+    it('returns attributes assigned to "static" property as they are', function() {
+      var type = 'text'
+
+      component.static = ['type']
+      componentRoot.setAttribute('type', type)
+      rivets.bind(element, locals)
+
+      component.initialize.calledWith(componentRoot, { item: locals.object, type: type }).should.be.true
+    })
+  })
+
+  describe('when "template" is a function', function() {
+    it('renders returned string as component template', function() {
+      component.template = sinon.stub().returns('<h1>{ name }</h1>')
+      rivets.bind(element)
+
+      componentRoot.innerHTML.should.equal('<h1>' + scope.name + '</h1>')
+    })
+  })
+
+})

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -22,6 +22,7 @@
     <script src="lib/parsers.js"></script>
     <script src="rivets/binders.js"></script>
     <script src="rivets/binding.js"></script>
+    <script src="rivets/component_binding.js"></script>
     <script src="rivets/functional.js"></script>
     <script src="rivets/routines.js"></script>
     <script src="rivets/text_template_parser.js"></script>

--- a/src/bindings.js
+++ b/src/bindings.js
@@ -278,18 +278,23 @@ export class ComponentBinding extends Binding {
     let bindingRegExp = view.bindingRegExp()
 
     if (this.el.attributes) {
-      this.el.attributes.forEach(attribute => {
+      let attribute = null
+      for (let i = 0 ; i < this.el.attributes.length ; i++) {
+        attribute = this.el.attributes[i]
         if (!bindingRegExp.test(attribute.name)) {
           let propertyName = this.camelCase(attribute.name)
           let stat = this.component.static
-
+          // Parse attribute value to check type (primitive, keypath...)
+          let token = parseType(attribute.value)
           if (stat && stat.indexOf(propertyName) > -1) {
             this.static[propertyName] = attribute.value
+          } else if (token.type === 0){
+            this.static[propertyName] = token.value
           } else {
             this.observers[propertyName] = attribute.value
           }
         }
-      })
+      }
     }
   }
 
@@ -379,8 +384,7 @@ export class ComponentBinding extends Binding {
         }
       })
 
-      this.componentView = new View(this.el, scope, options)
-      this.componentView.bind()
+      this.componentView = rivets.bind(this.el, scope, options)
 
       Object.keys(this.observers).forEach(key => {
         let observer = this.observers[key]


### PR DESCRIPTION
…ests for components reveal an error in forEach on attributes: attributes is not an array. An error was revealed too in View import : cyclic dependency between view and binding;

Two important notes on this report
1. Import of `View` from module `view.js` couldn't be resolved because `view.js` already used `bindings.js` in his imports. To break this cycle i replace `new View` by `rivets.bind()` which provides exactly the same result.
2. I introduced all components tests given by @blikblum. This revealed a bug due to use of `forEach` on element `attributes`. `attributes` is not an array and can not be browsed with `forEach`.