### PR TITLE
Fix uncorrect '0' receive by binders if html attribute is not defined

### DIFF
--- a/spec/rivets/binders.js
+++ b/spec/rivets/binders.js
@@ -172,4 +172,29 @@ describe("Rivets.binders", function() {
       Should(fragment.childNodes.length).be.exactly(1);
     });
   });
+ 
+  describe("Custom binder with no attribute value", function() {
+    rivets.binders["custom-binder"] = function(el, value) {
+      el.innerHTML = "received " + value;
+    };
+    beforeEach(function() {
+      fragment = document.createDocumentFragment();
+      el = document.createElement("div");
+
+      fragment.appendChild(el);
+
+      model = {};
+    });
+
+    it("receives undefined when html attribute is not specified", function() {
+      el.innerHTML = "<div rv-custom-binder></div>";
+      var view = rivets.bind(fragment, model);
+      Should(el.children[0].innerHTML).be.exactly('received undefined');
+    });
+    it("receives undefined when html attribute is not specified", function() {
+      el.innerHTML = "<div rv-custom-binder=''></div>";
+      var view = rivets.bind(fragment, model);
+      Should(el.children[0].innerHTML).be.exactly('received undefined');
+    });
+  });
 });

--- a/src/parsers.coffee
+++ b/src/parsers.coffee
@@ -23,6 +23,9 @@ class Rivets.TypeParser
       else if string is 'undefined'
         type: @types.primitive
         value: undefined
+      else if string is ''
+        type: @types.primitive
+        value: undefined
       else if isNaN(Number(string)) is false
         type: @types.primitive
         value: Number string


### PR DESCRIPTION
If html attribute is ```""``` or not defined, parser will receive ```""```. If so we send ```undefined``` to the binder 

Fix #568 