### PR TITLE
Add check to configurable before calling defineProperty

### DIFF
--- a/spec/rivets/binding.js
+++ b/spec/rivets/binding.js
@@ -32,8 +32,10 @@ describe('Rivets.Binding', function() {
       el.setAttribute('data-show', 'obj.items.length')
     })
 
-    it("does not throw", function() {
-      view = rivets.bind(el, {obj: data});
+    it('does not throw', function() {
+      (function(){
+        rivets.bind(el, { obj: data})
+      }).should.not.throw();
     })
 
   })

--- a/spec/rivets/binding.js
+++ b/spec/rivets/binding.js
@@ -17,6 +17,27 @@ describe('Rivets.Binding', function() {
     binding.binder.routine.should.equal(rivets.binders.text)
   })
 
+  describe('when bind to non configurable properties', function() {
+    beforeEach(function () {
+      data = {
+        name: 'x',
+        items: []
+      }
+      Object.defineProperty(data, 'name', {
+        enumerable: true,
+        configurable: false,
+        writable: true,
+        value: 'y'
+      });
+      el.setAttribute('data-show', 'obj.items.length')
+    })
+
+    it("does not throw", function() {
+      view = rivets.bind(el, {obj: data});
+    })
+
+  })
+
   describe('with formatters', function() {
     it('register all formatters', function() {
 
@@ -58,6 +79,7 @@ describe('Rivets.Binding', function() {
       binding.bind()
       binding.binder.bind.called.should.be.true
     })
+
 
     describe('with preloadData set to true', function() {
       beforeEach(function() {

--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -62,7 +62,7 @@ Rivets.public.adapters['.'] =
       callbacks[keypath] = []
       desc = Object.getOwnPropertyDescriptor obj, keypath
 
-      unless desc?.get or desc?.set
+      if !desc or !(desc.get or desc.set or !desc.configurable)
         value = obj[keypath]
 
         Object.defineProperty obj, keypath,


### PR DESCRIPTION
When  trying to to observe a non configurable property an exception is raised. This PR adds a check to avoid it.

Together with https://github.com/mikeric/sightglass/pull/14 will allow to observe array.length fixes this http://codepen.io/blikblum/pen/obQjWR and this https://github.com/mikeric/rivets/issues/278

With tests
