### PR TITLE
refactor(component): change nested function invocation

### DIFF
--- a/spec/rivets/component_binding.js
+++ b/spec/rivets/component_binding.js
@@ -19,6 +19,27 @@ describe('Component binding', function() {
     componentRoot.innerHTML.should.equal(component.template())
   })
 
+  describe('synchronization', function() {
+    var model
+
+    beforeEach(function() {
+      model = { title: 'test' }
+      componentRoot.setAttribute('title', 'title')
+      rivets.bind(element, model)
+      model.title = 'new title'
+    })
+
+    it('updates variable in component scope if appropriate attribute is changed', function() {
+      scope.title.should.equal(model.title)
+    })
+
+    it('updates parent view variable if appropriate variable is changed in component', function() {
+      scope.title = 'another value'
+
+      model.title.should.equal(scope.title)
+    })
+  })
+
   describe('initialize()', function() {
     var locals
 

--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -221,9 +221,9 @@ class Rivets.ComponentBinding extends Rivets.Binding
   bind: =>
     unless @bound
       for key, keypath of @observers
-        @observers[key] = @observe @view.models, keypath, ((key) => =>
-          @componentView.models[key] = @observers[key].value()
-        ).call(@, key)
+        do (key) =>
+          @observers[key] = @observe @view.models, keypath, =>
+            @upstreamObservers[key].setValue @observers[key].value()
 
       @bound = true
 
@@ -248,17 +248,15 @@ class Rivets.ComponentBinding extends Rivets.Binding
       @componentView.bind()
 
       for key, observer of @observers
-        @upstreamObservers[key] = @observe @componentView.models, key, ((key, observer) => =>
-          observer.setValue @componentView.models[key]
-        ).call(@, key, observer)
+        do (key, observer) =>
+          @upstreamObservers[key] = @observe @componentView.models, key, =>
+            observer.setValue @componentView.models[key]
     return
 
   # Intercept `Rivets.Binding::unbind` to be called on `@componentView`.
   unbind: =>
-    for key, observer of @upstreamObservers
-      observer.unobserve()
-
     for key, observer of @observers
+      @upstreamObservers[key].unobserve()
       observer.unobserve()
 
     @componentView?.unbind.call @


### PR DESCRIPTION
Basically this

``` js
for (key in _ref1) {
  keypath = _ref1[key];
  this.observers[key] = this.observe(this.view.models, keypath, ((function(_this) {
    return function(key) {
      return function() {
        return _this.componentView.models[key] = _this.observers[key].value();
      };
    };
  })(this)).call(this, key));
}
```

is replaced with

``` js
fn = (function(_this) {
  return function(key) {
    return _this.observers[key] = _this.observe(_this.view.models, keypath, function() {
      return _this.componentView.models[key] = _this.observers[key].value();
    });
 };
})(this);

for (key in _ref1) {
  keypath = _ref1[key];
  _fn(key);
}
```

that means no more odd function creation for each attribute and leads to faster components' creation
