### PR TITLE
fix(component binders): fix execution of binders applied to components

### DIFF
--- a/spec/rivets/binding.js
+++ b/spec/rivets/binding.js
@@ -1,7 +1,8 @@
 describe('Rivets.Binding', function() {
-  var model, el, view, binding, opts
+  var model, el, view, binding, opts, originalPrefix
 
   beforeEach(function() {
+    originalPrefix = rivets.prefix
     rivets.prefix = 'data'
     adapter = rivets.adapters['.']
 
@@ -11,6 +12,10 @@ describe('Rivets.Binding', function() {
     view = rivets.bind(el, {obj: {name: 'test'}})
     binding = view.bindings[0]
     model = binding.model
+  })
+
+  afterEach(function() {
+    rivets.prefix = originalPrefix
   })
 
   it('gets assigned the proper binder routine matching the identifier', function() {
@@ -94,7 +99,6 @@ describe('Rivets.Binding', function() {
     describe('with a binder.unbind defined', function() {
       beforeEach(function() {
         binding.binder.unbind = function(){}
-      
       })
 
       it('should not throw an error', function() {

--- a/spec/rivets/component_binding.js
+++ b/spec/rivets/component_binding.js
@@ -8,15 +8,25 @@ describe('Component binding', function() {
     scope = { name: 'Rivets' }
     component = rivets.components.test = {
       initialize: sinon.stub().returns(scope),
-      template: function() {}
+      template: function() { return '' }
     }
   })
 
   it('renders "template" as a string', function() {
-    rivets.components.test.template = function() {return '<h1>test</h1>'}
+    component.template = function() {return '<h1>test</h1>'}
     rivets.bind(element)
 
     componentRoot.innerHTML.should.equal(component.template())
+  })
+
+  it('binds binders on component root element only once', function() {
+    rivets.binders['test-binder'] = sinon.spy();
+    componentRoot.setAttribute('rv-test-binder', 'true');
+    rivets.bind(element);
+
+    rivets.binders['test-binder'].calledOnce.should.be.true;
+
+    delete rivets.binders['test-binder'];
   })
 
   describe('initialize()', function() {

--- a/spec/rivets/functional.js
+++ b/spec/rivets/functional.js
@@ -1,7 +1,9 @@
 describe('Functional', function() {
-  var data, bindData, el, input
+  var data, bindData, el, input, originalPrefix
 
   beforeEach(function() {
+    originalPrefix = rivets.prefix;
+    rivets.prefix = 'data';
     adapter = {
       observe: function(obj, keypath, callback) {
         obj.on(keypath, callback)
@@ -32,6 +34,10 @@ describe('Functional', function() {
     el = document.createElement('div')
     input = document.createElement('input')
     input.setAttribute('type', 'text')
+  })
+
+  afterEach(function() {
+    rivets.prefix = originalPrefix
   })
 
   describe('Adapter', function() {

--- a/src/bindings.coffee
+++ b/src/bindings.coffee
@@ -244,7 +244,7 @@ class Rivets.ComponentBinding extends Rivets.Binding
       for option in Rivets.options
         options[option] = @component[option] ? @view[option]
 
-      @componentView = new Rivets.View(@el, scope, options)
+      @componentView = new Rivets.View(Array.prototype.slice.call(@el.childNodes), scope, options)
       @componentView.bind()
 
       for key, observer of @observers


### PR DESCRIPTION
It fixes #596 and tests's state. Some tests rewrote `rivets.prefix = 'data'` and didn't change it back