### PR TITLE
Report for PR #612 Set bound to false when unbinding 'if' binder

### DIFF
--- a/spec/rivets/binders.js
+++ b/spec/rivets/binders.js
@@ -183,5 +183,23 @@ describe("Rivets.binders", function() {
       // 1 for the comment placeholder
       Should(fragment.childNodes.length).be.exactly(1);
     });
+
+    it("rebindes nested if", function() {
+       var nestedEl = document.createElement("div")
+       nestedEl.setAttribute("rv-if", "data.showNested");
+       nestedEl.innerHTML = "{ data.countNested }";
+       el.appendChild(nestedEl);
+  
+       var view = rivets.bind(fragment, model);
+  
+       model.data.countNested = "1";
+       model.data.showNested = true;
+       Should(nestedEl.innerHTML).be.exactly("1");
+       model.data.show = false;
+       model.data.show = true;
+       model.data.countNested = "42";
+  
+       Should(nestedEl.innerHTML).be.exactly("42");
+     });
   });
 });

--- a/src/binders.js
+++ b/src/binders.js
@@ -158,6 +158,7 @@ const binders = {
     unbind: function() {
       if (defined(this.nested)) {
         this.nested.unbind()
+        this.bound = false
       }
     },
 


### PR DESCRIPTION
Report PR #612 on ES6 branch. Fixes #611 