### PR TITLE
bug #616 - sync TextBinding after updating it

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -140,5 +140,7 @@ class Rivets.View
   # Updates the view's models along with any affected bindings.
   update: (models = {}) =>
     @models[key] = model for key, model of models
-    binding.update? models for binding in @bindings
+    for binding in @bindings
+      binding.update? models
+      binding.sync() if binding instanceof Rivets.TextBinding
     return


### PR DESCRIPTION
I'm new to CoffeeScript so please excuse me for some syntactical errors below. The goal here is to indicate a solution to [bug #616]. The resulting change to View.update solves this bug.

`
    // Seems like its safe to call sync on all bindings but adding the following check just to be safe
    if(binding instanceof Rivets.TextBinding){
      binding.sync();
    }
`