### PR TITLE
fix: get either `window.jQuery or window.$`, not always `jQuery`

### DIFF
--- a/src/util.coffee
+++ b/src/util.coffee
@@ -2,6 +2,7 @@
 # -----------
 
 if window['jQuery'] or window['$']
+  jQuery = window['jQuery'] or window['$']
   [bindMethod, unbindMethod] = if 'on' of jQuery.prototype then ['on', 'off'] else ['bind', 'unbind']
 
   Rivets.Util =


### PR DESCRIPTION
Fixes #646 however another solution would be to simply not check for `window['$']`. Please advice or merge it.

Note: I didn't update `dist` folder or change package version.