### PR TITLE
binders: Always bind to input change event

### DIFF
--- a/src/binders.coffee
+++ b/src/binders.coffee
@@ -72,8 +72,9 @@ Rivets.public.binders.value =
 
   bind: (el) ->
     unless el.tagName is 'INPUT' and el.type is 'radio'
-      @event = if el.tagName is 'SELECT' then 'change' else 'input'
-      Rivets.Util.bindEvent el, @event, @publish
+      Rivets.Util.bindEvent el, 'change', @publish
+      unless el.tagName is 'SELECT'
+        Rivets.Util.bindEvent el, 'input', @publish
 
   unbind: (el) ->
     unless el.tagName is 'INPUT' and el.type is 'radio'


### PR DESCRIPTION
Many inputs are not modified directly by the user interacting directly, or by the app programmer via rivets. Instead, they may be modified by third party plugins. These plugins normally use the change event to notify that it has done something. Integrating rivets with such plugins is a pain, as the app programmer needs to create a new binder.

Fixes #610 
## 

AFAICS, the only downside to this change is that for user-interacting inputs the change event handling will be redundant.
