### PR TITLE
docs: Fix simple typo, succint -> succinct

### DIFF
--- a/docs/docs/guide/_sections/adapters.md
+++ b/docs/docs/guide/_sections/adapters.md
@@ -6,4 +6,4 @@ Each adapter is defined to a unique interface (a single character) which is used
 user.address:city
 ```
 
-The above keypath will use the `.` adapter to access the `address` key on the `user` object, and the `:` adapter to access the `city` key on the `address` object. If you can imagine for a second that `address` is just a normal property on the user object pointing to a Backbone model, but `city` is actually an attribute on that Backbone model, you can see how this kind of notation is actually very succint and expressive.
+The above keypath will use the `.` adapter to access the `address` key on the `user` object, and the `:` adapter to access the `city` key on the `address` object. If you can imagine for a second that `address` is just a normal property on the user object pointing to a Backbone model, but `city` is actually an attribute on that Backbone model, you can see how this kind of notation is actually very succinct and expressive.


### PR DESCRIPTION
There is a small typo in docs/docs/guide/_sections/adapters.md.

Should read `succinct` rather than `succint`.

